### PR TITLE
:alien: Reduce the session cookie security to Lax

### DIFF
--- a/src/woo_publications/conf/docker.py
+++ b/src/woo_publications/conf/docker.py
@@ -11,6 +11,8 @@ os.environ.setdefault("LOG_STDOUT", "yes")
 os.environ.setdefault("CACHE_DEFAULT", "redis:6379/0")
 os.environ.setdefault("CACHE_AXES", "redis:6379/0")
 
+os.environ.setdefault("SESSION_COOKIE_SAMESITE", "Lax")
+
 # # Strongly suggested to not use this, but explicitly list the allowed hosts. It is
 # used to verify if a redirect is safe or not (open redirect vulnerabilities etc.)
 # os.environ.setdefault("ALLOWED_HOSTS", "*")


### PR DESCRIPTION
Ideally we set this to Strict, but the session cookie is now not sent during redirects from OIDC providers (like Google, Azure, Keycloak) after succesful authentication, causing crashes on our end because we don't have access to the OIDC state and therefore we have a broken reference to the OIDC config model being used.

See https://github.com/mozilla/mozilla-django-oidc/issues/497 for more information - in summary the best solution would be to set it to Strict, but temporarily reduce this to Lax during the OIDC flow (possibly via middleware), which will require overriding some django.contrib.sessions middleware.
