### PR TITLE
:wrench: Uninstall django.contrib.sites from default apps

### DIFF
--- a/src/woo_publications/accounts/tests/test_oidc.py
+++ b/src/woo_publications/accounts/tests/test_oidc.py
@@ -81,9 +81,9 @@ class OIDCFLowTests(VCRMixin, WebTest):
             self.assertEqual(error_page.status_code, 200)
             self.assertEqual(error_page.request.path, reverse("admin-oidc-error"))
             self.assertEqual(
-                error_page.context["oidc_error"],
+                error_page.context["oidc_error"].strip(),
                 'duplicate key value violates unique constraint "filled_email_unique"\n'
-                "DETAIL:  Key (email)=(admin@example.com) already exists.\n",
+                "DETAIL:  Key (email)=(admin@example.com) already exists.",
             )
             self.assertContains(
                 error_page, "duplicate key value violates unique constraint"

--- a/src/woo_publications/conf/base.py
+++ b/src/woo_publications/conf/base.py
@@ -11,6 +11,8 @@ TIME_ZONE = "Europe/Amsterdam"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+INSTALLED_APPS.remove("django.contrib.sites")
+
 INSTALLED_APPS = INSTALLED_APPS + [
     # External applications.
     "capture_tag",

--- a/src/woo_publications/fixtures/default_admin_index.json
+++ b/src/woo_publications/fixtures/default_admin_index.json
@@ -108,10 +108,6 @@
                 "certificate"
             ],
             [
-                "sites",
-                "site"
-            ],
-            [
                 "two_factor_webauthn",
                 "webauthndevice"
             ],


### PR DESCRIPTION
Fixes #27

**Changes**

Ensure that `django.contrib.sites` is not enabled.

