### PR TITLE
:mute: Shut up logging output in CI and dev when running tests

### DIFF
--- a/src/woo_publications/conf/ci.py
+++ b/src/woo_publications/conf/ci.py
@@ -6,6 +6,7 @@ os.environ.setdefault("SECRET_KEY", "for-testing-purposes-only")
 os.environ.setdefault("LOG_REQUESTS", "no")
 
 from .base import *  # noqa isort:skip
+from .utils import mute_logging  # noqa isort:skip
 
 CACHES.update(
     {
@@ -13,6 +14,9 @@ CACHES.update(
         "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
     }
 )
+
+# shut up logging
+mute_logging(LOGGING)
 
 # don't spend time on password hashing in tests/user factories
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.UnsaltedMD5PasswordHasher"]

--- a/src/woo_publications/conf/dev.py
+++ b/src/woo_publications/conf/dev.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import warnings
 
 os.environ.setdefault("DEBUG", "yes")
@@ -21,6 +22,7 @@ os.environ.setdefault("LOG_STDOUT", "1")
 os.environ.setdefault("VCR_RECORD_MODE", "once")
 
 from .base import *  # noqa isort:skip
+from .utils import mute_logging  # noqa isort:skip
 
 # Feel free to switch dev to sqlite3 for simple projects,
 # os.environ.setdefault("DB_ENGINE", "django.db.backends.sqlite3")
@@ -64,6 +66,11 @@ CACHES.update(
         "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
     }
 )
+
+if "test" in sys.argv:
+    if "VERBOSE" not in os.environ:
+        # shut up logging
+        mute_logging(LOGGING)
 
 #
 # Library settings

--- a/src/woo_publications/conf/utils.py
+++ b/src/woo_publications/conf/utils.py
@@ -45,3 +45,25 @@ def get_sentry_integrations() -> list:
         extra.append(celery.CeleryIntegration())
 
     return [*default, *extra]
+
+
+def mute_logging(config: dict) -> None:  # pragma: no cover
+    """
+    Disable (console) output from logging.
+
+    :arg config: The logging config, typically the django LOGGING setting.
+    """
+
+    # set up the null handler for all loggers so that nothing gets emitted
+    for name, logger in config["loggers"].items():
+        if name == "flaky_tests":
+            continue
+        logger["handlers"] = ["null"]
+
+    # some tooling logs to a logger which isn't defined, and that ends up in the root
+    # logger -> add one so that we can mute that output too.
+    config["loggers"].update(
+        {
+            "": {"handlers": ["null"], "level": "CRITICAL", "propagate": False},
+        }
+    )


### PR DESCRIPTION
Ensure that the validation/permission error logging doesn't clutter the stdout/stderr output when running tests.

All I want to see is dots, F, E, x and S :)
