### PR TITLE
Fix crash on user edit because of related queryset data

### DIFF
--- a/src/woo_publications/accounts/tests/test_admin.py
+++ b/src/woo_publications/accounts/tests/test_admin.py
@@ -1,0 +1,28 @@
+from django.test import tag
+from django.urls import reverse
+
+from django_webtest import WebTest
+from maykin_2fa.test import disable_admin_mfa
+
+from .factories import UserFactory
+
+
+@disable_admin_mfa()
+class UserAdminTests(WebTest):
+
+    @tag("gh-81")
+    def test_can_set_user_permissions(self):
+        superuser = UserFactory.create(superuser=True)
+        other_user = UserFactory.create()
+        change_page = self.app.get(
+            reverse("admin:accounts_user_change", args=(other_user.pk,)),
+            user=superuser,
+        )
+        change_form = change_page.forms["user_form"]
+        change_form["user_permissions"].select_multiple(
+            texts=["accounts | gebruiker | Can add user"]
+        )
+
+        response = change_form.submit(name="_save")
+
+        self.assertEqual(response.status_code, 302)

--- a/src/woo_publications/logging/serializing.py
+++ b/src/woo_publications/logging/serializing.py
@@ -3,18 +3,24 @@ from itertools import chain
 from django.db import models
 
 
-def model_to_dict(instance, fields=None, exclude=None):
+def model_to_dict(instance):
     """
-    Modified version of django.forms.model_to_dict which doesn't skip non-editable fields.
+    Modified version of django.forms.model_to_dict.
+
+    * it doesn't skip non-editable fields
+    * it serializes related objects to their PK instead of passing model instances
     """
     opts = instance._meta
     data = {}
     for f in chain(opts.concrete_fields, opts.private_fields, opts.many_to_many):
-        if fields is not None and f.name not in fields:
-            continue
-        if exclude and f.name in exclude:
-            continue
-        data[f.name] = f.value_from_object(instance)
+        value = f.value_from_object(instance)
+        match f:
+            case models.ManyToManyField():
+                value = [obj.pk for obj in value]
+            case _:
+                pass
+        data[f.name] = value
+
     return data
 
 


### PR DESCRIPTION
Fixes #81

**Changes**

Simplified the serialization used in audit trail object data snapshotting.

