### PR TITLE
:sparkles: [#50] Add links to audit trail logs in admin

### DIFF
--- a/docs/developers/audit_logging.rst
+++ b/docs/developers/audit_logging.rst
@@ -19,6 +19,8 @@ Mixins/helper classes for :class:`django.contrib.admin.ModelAdmin` and related c
 .. autoclass:: woo_publications.logging.service.AuditLogInlineformset
     :members:
 
+.. autofunction:: woo_publications.logging.service.get_logs_link
+
 DRF integration
 ---------------
 

--- a/src/woo_publications/accounts/admin.py
+++ b/src/woo_publications/accounts/admin.py
@@ -3,10 +3,12 @@ from django.contrib.admin.utils import unquote
 from django.contrib.auth.admin import UserAdmin as _UserAdmin
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.urls import reverse_lazy
+from django.utils.html import format_html_join
+from django.utils.translation import gettext_lazy as _
 
 from hijack.contrib.admin import HijackUserAdminMixin
 
-from woo_publications.logging.service import AdminAuditLogMixin
+from woo_publications.logging.service import AdminAuditLogMixin, get_logs_link
 
 from .forms import PreventPrivilegeEscalationMixin, UserChangeForm
 from .models import User
@@ -15,6 +17,14 @@ from .utils import validate_max_user_permissions
 
 @admin.register(User)
 class UserAdmin(AdminAuditLogMixin, HijackUserAdminMixin, _UserAdmin):
+    list_display = (
+        "username",
+        "email",
+        "first_name",
+        "last_name",
+        "is_staff",
+        "show_actions",
+    )
     hijack_success_url = reverse_lazy("root")
     form = UserChangeForm
 
@@ -37,3 +47,14 @@ class UserAdmin(AdminAuditLogMixin, HijackUserAdminMixin, _UserAdmin):
             raise PermissionDenied from exc
 
         return super().user_change_password(request, id, form_url)
+
+    @admin.display(description=_("actions"))
+    def show_actions(self, obj: User) -> str:
+        actions = [
+            get_logs_link(obj),
+        ]
+        return format_html_join(
+            " | ",
+            '<a href="{}">{}</a>',
+            actions,
+        )

--- a/src/woo_publications/logging/admin_tools.py
+++ b/src/woo_publications/logging/admin_tools.py
@@ -1,5 +1,10 @@
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.forms import BaseInlineFormSet
+from django.urls import reverse
+from django.utils.translation import gettext
+
+from furl import furl
 
 from woo_publications.accounts.models import User
 
@@ -98,3 +103,17 @@ class AuditLogInlineformset(BaseInlineFormSet):
         )
 
         return super().save_existing(form, obj, commit)
+
+
+def get_logs_link(obj: models.Model) -> tuple[str, str]:
+    """
+    Return a tuple of ``url`` and ``label`` to display logs related to ``obj``.
+    """
+    path = reverse("admin:logging_timelinelogproxy_changelist")
+    url = furl(path).add(
+        {
+            "content_type__exact": ContentType.objects.get_for_model(obj).pk,
+            "object_id": obj.pk,
+        }
+    )
+    return str(url), gettext("Show logs")

--- a/src/woo_publications/logging/service.py
+++ b/src/woo_publications/logging/service.py
@@ -1,4 +1,4 @@
-from .admin_tools import AdminAuditLogMixin, AuditLogInlineformset
+from .admin_tools import AdminAuditLogMixin, AuditLogInlineformset, get_logs_link
 from .api_tools import (
     AuditTrailCreateMixin,
     AuditTrailDestroyMixin,
@@ -21,6 +21,7 @@ __all__ = [
     # Admin
     "AdminAuditLogMixin",
     "AuditLogInlineformset",
+    "get_logs_link",
     # API
     "AuditTrailCreateMixin",
     "AuditTrailRetrieveMixin",

--- a/src/woo_publications/metadata/admin.py
+++ b/src/woo_publications/metadata/admin.py
@@ -1,10 +1,12 @@
 from django.contrib import admin
+from django.utils.html import format_html_join
+from django.utils.translation import gettext_lazy as _
 
 from ordered_model.admin import OrderedModelAdmin
 from treebeard.admin import TreeAdmin
 from treebeard.forms import movenodeform_factory
 
-from woo_publications.logging.service import AdminAuditLogMixin
+from woo_publications.logging.service import AdminAuditLogMixin, get_logs_link
 
 from .constants import InformationCategoryOrigins
 from .models import InformationCategory, Theme
@@ -12,7 +14,13 @@ from .models import InformationCategory, Theme
 
 @admin.register(InformationCategory)
 class InformationCategoryAdmin(AdminAuditLogMixin, OrderedModelAdmin):
-    list_display = ("naam", "identifier", "oorsprong", "move_up_down_links")
+    list_display = (
+        "naam",
+        "identifier",
+        "oorsprong",
+        "show_actions",
+        "move_up_down_links",
+    )
     readonly_fields = (
         "uuid",
         "oorsprong",
@@ -28,12 +36,21 @@ class InformationCategoryAdmin(AdminAuditLogMixin, OrderedModelAdmin):
             return False
         return True
 
+    @admin.display(description=_("actions"))
+    def show_actions(self, obj: InformationCategory) -> str:
+        actions = [
+            get_logs_link(obj),
+        ]
+        return format_html_join(
+            " | ",
+            '<a href="{}">{}</a>',
+            actions,
+        )
+
 
 @admin.register(Theme)
-class ThemeAdmin(
-    AdminAuditLogMixin, TreeAdmin
-):  # use Model admin because nothing should be editable anyway
-    list_display = ("naam", "identifier")
+class ThemeAdmin(AdminAuditLogMixin, TreeAdmin):
+    list_display = ("naam", "identifier", "show_actions")
     search_fields = ("identifier", "naam")
     form = movenodeform_factory(Theme)
 
@@ -42,3 +59,14 @@ class ThemeAdmin(
 
     def has_add_permission(self, request, obj=None):
         return False
+
+    @admin.display(description=_("actions"))
+    def show_actions(self, obj: Theme) -> str:
+        actions = [
+            get_logs_link(obj),
+        ]
+        return format_html_join(
+            " | ",
+            '<a href="{}">{}</a>',
+            actions,
+        )

--- a/src/woo_publications/publications/admin.py
+++ b/src/woo_publications/publications/admin.py
@@ -6,7 +6,11 @@ from django.utils.translation import gettext_lazy as _
 
 from furl import furl
 
-from woo_publications.logging.service import AdminAuditLogMixin, AuditLogInlineformset
+from woo_publications.logging.service import (
+    AdminAuditLogMixin,
+    AuditLogInlineformset,
+    get_logs_link,
+)
 
 from .models import Document, Publication
 
@@ -47,7 +51,8 @@ class PublicationAdmin(AdminAuditLogMixin, admin.ModelAdmin):
                     {"publicatie__exact": obj.pk}
                 ),
                 _("Show documents"),
-            )
+            ),
+            get_logs_link(obj),
         ]
         return format_html_join(
             " | ",
@@ -65,6 +70,7 @@ class DocumentAdmin(AdminAuditLogMixin, admin.ModelAdmin):
         "show_filesize",
         "identifier",
         "registratiedatum",
+        "show_actions",
     )
     search_fields = (
         "identifier",
@@ -79,3 +85,14 @@ class DocumentAdmin(AdminAuditLogMixin, admin.ModelAdmin):
     @admin.display(description=_("file size"), ordering="bestandsomvang")
     def show_filesize(self, obj: Document) -> str:
         return filesizeformat(obj.bestandsomvang)
+
+    @admin.display(description=_("actions"))
+    def show_actions(self, obj: Document) -> str:
+        actions = [
+            get_logs_link(obj),
+        ]
+        return format_html_join(
+            " | ",
+            '<a href="{}">{}</a>',
+            actions,
+        )


### PR DESCRIPTION
Fixes #50

**Changes**

Ensure that audit-trail enabled models in the admin have a link/action to navigate to the related log records.

