### PR TITLE
Add missing camelCase to snake_case conversion via middleware

### DIFF
--- a/src/woo_publications/conf/base.py
+++ b/src/woo_publications/conf/base.py
@@ -35,6 +35,11 @@ INSTALLED_APPS.remove("notifications_api_common")
 
 MIDDLEWARE = MIDDLEWARE + [
     "hijack.middleware.HijackUserMiddleware",
+    # NOTE: affects *all* requests, not just API calls. We can't subclass (yet) either
+    # to modify the behaviour, since drf-spectacular has a bug in its `issubclass`
+    # check, which is unreleased at the time of writing:
+    # https://github.com/tfranzel/drf-spectacular/commit/71c7a04ee8921c01babb11fbe2938397a372dac7
+    "djangorestframework_camel_case.middleware.CamelCaseMiddleWare",
 ]
 
 # Remove unused/irrelevant middleware added by OAF


### PR DESCRIPTION
Closes #98

The drf-camel-case middleware was not installed, causing the runtime behaviour to be wrong.

I'm not sure why the API documentation generates camelCase query params though, since it's supposed to only do that when the middleware is installed :thinking:.
