### PR TITLE
:lipstick: Fix ugly vertical stretching in form fields with long labels

### DIFF
--- a/src/woo_publications/scss/admin/_admin_theme.scss
+++ b/src/woo_publications/scss/admin/_admin_theme.scss
@@ -171,6 +171,17 @@ div.breadcrumbs {
   }
 }
 
+// prevent input fields from stretching vertically on wrapping labels
+.form-row .flex-container {
+  input {
+    align-self: start;
+  }
+  .related-lookup {
+    align-self: start;
+    margin-block-start: 5px;
+  }
+}
+
 /**
  * Django form related widget
  */


### PR DESCRIPTION
The long label causes the flex input to be stretched across the whole column, and also messes up the search icon. There does not appear to be a Django ticket for this yet, should probably be checked in newer versions and a ticket created if necessary.

-> you see this happening on the information categories m2m field on the publication admin