### PR TITLE
Readable informatiecategorien admin field.

### DIFF
--- a/src/woo_publications/publications/admin.py
+++ b/src/woo_publications/publications/admin.py
@@ -30,7 +30,7 @@ class PublicationAdmin(AdminAuditLogMixin, admin.ModelAdmin):
         "uuid",
         "show_actions",
     )
-    raw_id_fields = ("informatie_categorieen",)
+    autocomplete_fields = ("informatie_categorieen",)
     readonly_fields = (
         "uuid",
         "registratiedatum",

--- a/src/woo_publications/publications/tests/test_admin_logging.py
+++ b/src/woo_publications/publications/tests/test_admin_logging.py
@@ -41,7 +41,8 @@ class TestAdminAuditLogging(WebTest):
         self.assertEqual(response.status_code, 200)
 
         form = response.forms["publication_form"]
-        form["informatie_categorieen"] = f"{ic.pk},{ic2.pk}"
+        # Force the value because the select box options get loaded in with js
+        form["informatie_categorieen"].force_value([ic.id, ic2.id])
         form["officiele_titel"] = "The official title of this publication"
         form["verkorte_titel"] = "The title"
         form["omschrijving"] = (
@@ -95,7 +96,7 @@ class TestAdminAuditLogging(WebTest):
         self.assertEqual(response.status_code, 200)
 
         form = response.forms["publication_form"]
-        form["informatie_categorieen"] = str(ic.pk)
+        form["informatie_categorieen"].select_multiple(texts=[ic.naam])
         form["officiele_titel"] = "changed official title"
         form["verkorte_titel"] = "changed short title"
         form["omschrijving"] = "changed description"

--- a/src/woo_publications/publications/tests/test_publications_admin.py
+++ b/src/woo_publications/publications/tests/test_publications_admin.py
@@ -148,7 +148,8 @@ class TestPublicationsAdmin(WebTest):
             )
 
         with self.subTest("complete data creates publication"):
-            form["informatie_categorieen"] = f"{ic.pk},{ic2.pk},{ic3.pk}"
+            # Force the value because the select box options get loaded in with js
+            form["informatie_categorieen"].force_value([ic.id, ic2.id, ic3.id])
             form["officiele_titel"] = "The official title of this publication"
             form["verkorte_titel"] = "The title"
             form["omschrijving"] = (
@@ -215,7 +216,7 @@ class TestPublicationsAdmin(WebTest):
             )
 
         with self.subTest("complete data updates publication"):
-            form["informatie_categorieen"] = str(ic.pk)
+            form["informatie_categorieen"].select_multiple(texts=[ic.naam])
             form["officiele_titel"] = "changed official title"
             form["verkorte_titel"] = "changed short title"
             form["omschrijving"] = "changed description"


### PR DESCRIPTION
Fixes #48

**Changes**

- changed Informatiecategories field from raw_id_field to autocompletefield
