### PR TITLE
Revoke documents when revoking publication

### DIFF
--- a/docs/admin/publicaties/index.rst
+++ b/docs/admin/publicaties/index.rst
@@ -47,6 +47,7 @@ Op een *document*-registratie zijn de volgende metadata beschikbaar. Op het sche
 * ``Bestandsformaat``. *In ontwikkeling* (DiWoo : ``format``)
 * ``Bestandsnaam``. Naam van het bestand zoals deze op de harde schijf opgeslagen wordt.
 * ``Bestandsomvang`` Bestandsgrootte, in aantal bytes.
+* ``Status``. De publicatiestatus van het document (DiWoo : ``publicatiestatus``)
 * ``Documents API Service``. Systeemveld, bevat de verwijzing naar het bestand in de Documenten API.
 * ``Document UUID``. Systeemveld, bevat de verwijzing naar het bestand in de Documenten API.
 * ``Geregistreerd op``. De niet-wijzigbare datum en tijd waarop het document nieuw is toegevoegd.
@@ -103,6 +104,7 @@ Op een *publicatie*-registratie zijn de volgende metadata beschikbaar. Op het sc
 * ``Officiële titel``. De (mogelijk uitgebreide) officiële titel van de publicatie. (DiWoo : ``officieleTitel``)
 * ``Verkorte titel``. De verkorte titel / citeertitel van de publicatie. (DiWoo : ``verkorteTitel``)
 * ``Omschrijving``. Een beknopte omschrijving / samenvatting van de publicatie. (DiWoo : ``omschrijving``)
+* ``Status``. De publicatiestatus van de publicatie **LET OP**: wanneer de publicatie ingetrokken wordt, worden de gepubliceerde documenten ook ingetrokken. (DiWoo : ``publicatiestatus``)
 * ``Publicatie``. Het *document* moet hier gekoppeld worden aan een bestaande of nieuwe *publicatie*
 * ``UUID``. Een niet-wijzigbaar, automatisch toegekend identificatiekenmerk. (DiWoo : ``identifier``)
 * ``Geregistreerd op``. De niet-wijzigbare datum en tijd waarop de publicatie nieuw is toegevoegd.

--- a/src/woo_publications/api/openapi.yaml
+++ b/src/woo_publications/api/openapi.yaml
@@ -1598,7 +1598,7 @@ components:
 
             **Disclaimer**: you can't create a revoked publication.
 
-            **Disclaimer**: when you revoked a publication, the attached published documents also get's revoked.
+            **Disclaimer**: when you revoke a publication, the attached published documents also get revoked.
 
             * `gepubliceerd` - Published
             * `concept` - Concept
@@ -1681,7 +1681,7 @@ components:
 
             **Disclaimer**: you can't create a revoked publication.
 
-            **Disclaimer**: when you revoked a publication, the attached published documents also get's revoked.
+            **Disclaimer**: when you revoke a publication, the attached published documents also get revoked.
 
             * `gepubliceerd` - Published
             * `concept` - Concept

--- a/src/woo_publications/api/openapi.yaml
+++ b/src/woo_publications/api/openapi.yaml
@@ -1598,6 +1598,8 @@ components:
 
             **Disclaimer**: you can't create a revoked publication.
 
+            **Disclaimer**: when you revoked a publication, the attached published documents also get's revoked.
+
             * `gepubliceerd` - Published
             * `concept` - Concept
             * `ingetrokken` - Revoked
@@ -1678,6 +1680,8 @@ components:
           description: |2-
 
             **Disclaimer**: you can't create a revoked publication.
+
+            **Disclaimer**: when you revoked a publication, the attached published documents also get's revoked.
 
             * `gepubliceerd` - Published
             * `concept` - Concept

--- a/src/woo_publications/logging/service.py
+++ b/src/woo_publications/logging/service.py
@@ -5,6 +5,7 @@ from .api_tools import (
     AuditTrailRetrieveMixin,
     AuditTrailUpdateMixin,
     AuditTrailViewSetMixin,
+    extract_audit_parameters,
 )
 from .logevent import (
     audit_admin_create,
@@ -28,6 +29,7 @@ __all__ = [
     "AuditTrailUpdateMixin",
     "AuditTrailDestroyMixin",
     "AuditTrailViewSetMixin",
+    "extract_audit_parameters",
     # Low level helpers
     # * admin
     "audit_admin_create",

--- a/src/woo_publications/publications/admin.py
+++ b/src/woo_publications/publications/admin.py
@@ -59,6 +59,11 @@ class PublicationAdmin(AdminAuditLogMixin, admin.ModelAdmin):
             return False
         return super().has_change_permission(request, obj)
 
+    def save_model(self, request, obj, form, change):
+        if obj.publicatiestatus == PublicationStatusOptions.revoked:
+            obj.revoke_own_published_documents()
+        super().save_model(request, obj, form, change)
+
     @admin.display(description=_("actions"))
     def show_actions(self, obj: Publication) -> str:
         actions = [

--- a/src/woo_publications/publications/admin.py
+++ b/src/woo_publications/publications/admin.py
@@ -61,7 +61,7 @@ class PublicationAdmin(AdminAuditLogMixin, admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         if obj.publicatiestatus == PublicationStatusOptions.revoked:
-            obj.revoke_own_published_documents()
+            obj.revoke_own_published_documents(request.user)
         super().save_model(request, obj, form, change)
 
     @admin.display(description=_("actions"))

--- a/src/woo_publications/publications/api/serializers.py
+++ b/src/woo_publications/publications/api/serializers.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
@@ -212,3 +213,12 @@ class PublicationSerializer(serializers.ModelSerializer[Publication]):
                 )
 
         return value
+
+    @transaction.atomic
+    def update(self, instance, validated_data):
+        publication = super().update(instance, validated_data)
+
+        if validated_data.get("publicatiestatus") == PublicationStatusOptions.revoked:
+            publication.revoke_own_published_documents()
+
+        return publication

--- a/src/woo_publications/publications/api/serializers.py
+++ b/src/woo_publications/publications/api/serializers.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 from woo_publications.contrib.documents_api.client import FilePart
+from woo_publications.logging.service import extract_audit_parameters
 from woo_publications.metadata.models import InformationCategory, Organisation
 
 from ..constants import PublicationStatusOptions
@@ -223,6 +224,12 @@ class PublicationSerializer(serializers.ModelSerializer[Publication]):
         publication = super().update(instance, validated_data)
 
         if validated_data.get("publicatiestatus") == PublicationStatusOptions.revoked:
-            publication.revoke_own_published_documents()
+            user_id, user_repr, remarks = extract_audit_parameters(
+                self.context["request"]
+            )
+
+            publication.revoke_own_published_documents(
+                user={"user_id": user_id, "user_repr": user_repr}, remarks=remarks
+            )
 
         return publication

--- a/src/woo_publications/publications/api/serializers.py
+++ b/src/woo_publications/publications/api/serializers.py
@@ -187,10 +187,9 @@ class PublicationSerializer(serializers.ModelSerializer[Publication]):
             "publicatiestatus": {
                 "help_text": _(
                     "\n**Disclaimer**: you can't create a {revoked} publication."
-                    "\n\n**Disclaimer**: when you {revoked} a publication, the attached {published} documents also get's {revoked}."
+                    "\n\n**Disclaimer**: when you revoke a publication, the attached published documents also get revoked."
                 ).format(
                     revoked=PublicationStatusOptions.revoked.label.lower(),
-                    published=PublicationStatusOptions.published.label.lower(),
                 )
             },
         }
@@ -221,6 +220,7 @@ class PublicationSerializer(serializers.ModelSerializer[Publication]):
 
     @transaction.atomic
     def update(self, instance, validated_data):
+        assert instance.publicatiestatus != PublicationStatusOptions.revoked
         publication = super().update(instance, validated_data)
 
         if validated_data.get("publicatiestatus") == PublicationStatusOptions.revoked:
@@ -229,7 +229,7 @@ class PublicationSerializer(serializers.ModelSerializer[Publication]):
             )
 
             publication.revoke_own_published_documents(
-                user={"user_id": user_id, "user_repr": user_repr}, remarks=remarks
+                user={"identifier": user_id, "display_name": user_repr}, remarks=remarks
             )
 
         return publication

--- a/src/woo_publications/publications/api/serializers.py
+++ b/src/woo_publications/publications/api/serializers.py
@@ -186,7 +186,11 @@ class PublicationSerializer(serializers.ModelSerializer[Publication]):
             "publicatiestatus": {
                 "help_text": _(
                     "\n**Disclaimer**: you can't create a {revoked} publication."
-                ).format(revoked=PublicationStatusOptions.revoked.label.lower())
+                    "\n\n**Disclaimer**: when you {revoked} a publication, the attached {published} documents also get's {revoked}."
+                ).format(
+                    revoked=PublicationStatusOptions.revoked.label.lower(),
+                    published=PublicationStatusOptions.published.label.lower(),
+                )
             },
         }
 

--- a/src/woo_publications/publications/models.py
+++ b/src/woo_publications/publications/models.py
@@ -3,6 +3,7 @@ from typing import Callable
 
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework.reverse import reverse
@@ -150,6 +151,7 @@ class Publication(models.Model):
             case User():
                 for document in documents:
                     document.publicatiestatus = PublicationStatusOptions.revoked
+                    document.laatst_gewijzigd_datum = timezone.now()
                     audit_admin_update(
                         content_object=document,
                         django_user=user,
@@ -159,6 +161,7 @@ class Publication(models.Model):
                 assert remarks
                 for document in documents:
                     document.publicatiestatus = PublicationStatusOptions.revoked
+                    document.laatst_gewijzigd_datum = timezone.now()
                     audit_api_update(
                         content_object=document,
                         user_id=user["user_id"],
@@ -167,7 +170,10 @@ class Publication(models.Model):
                         remarks=remarks,
                     )
 
-        Document.objects.bulk_update(documents, ["publicatiestatus"])
+        # manually update laatst_gewijzigd_datum because bulk_update doesn't trigger save method.
+        Document.objects.bulk_update(
+            documents, ["publicatiestatus", "laatst_gewijzigd_datum"]
+        )
 
 
 class Document(models.Model):

--- a/src/woo_publications/publications/models.py
+++ b/src/woo_publications/publications/models.py
@@ -121,11 +121,6 @@ class Publication(models.Model):
                 )
             )
 
-    def save(self, *args, **kwargs):
-        if self.pk and self.publicatiestatus == PublicationStatusOptions.revoked:
-            self.revoke_own_published_documents()
-        super().save(*args, **kwargs)
-
     def get_owner(self) -> ActingUser | None:
         """
         Extract the owner from the audit trails.

--- a/src/woo_publications/publications/tests/test_admin_logging.py
+++ b/src/woo_publications/publications/tests/test_admin_logging.py
@@ -245,7 +245,7 @@ class TestPublicationAdminAuditLogging(WebTest):
         self.assertEqual(TimelineLogProxy.objects.count(), 3)
 
         with self.subTest("update publication audit logging"):
-            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore reportAttributeAccessIssue
+            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore[reportAttributeAccessIssue]
                 publication
             ).get(
                 extra_data__event=Events.update
@@ -277,7 +277,7 @@ class TestPublicationAdminAuditLogging(WebTest):
             self.assertEqual(update_publication_log.extra_data, expected_data)
 
         with self.subTest("update document audit logging"):
-            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore reportAttributeAccessIssue
+            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore[reportAttributeAccessIssue]
                 published_document
             ).get()
 

--- a/src/woo_publications/publications/tests/test_admin_logging.py
+++ b/src/woo_publications/publications/tests/test_admin_logging.py
@@ -175,6 +175,142 @@ class TestPublicationAdminAuditLogging(WebTest):
 
             self.assertEqual(update_log.extra_data, expected_data)
 
+    def test_admin_update_revoke_published_documents_when_revoking_publication(self):
+        assert not TimelineLogProxy.objects.exists()
+        ic, ic2 = InformationCategoryFactory.create_batch(2)
+        organisation = OrganisationFactory.create(is_actief=True)
+        with freeze_time("2024-09-27T00:14:00-00:00"):
+            publication = PublicationFactory.create(
+                publisher=organisation,
+                verantwoordelijke=organisation,
+                opsteller=organisation,
+                informatie_categorieen=[ic, ic2],
+                officiele_titel="title one",
+                verkorte_titel="one",
+                omschrijving="Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            )
+            published_document = DocumentFactory.create(
+                publicatie=publication,
+                publicatiestatus=PublicationStatusOptions.published,
+                identifier="http://example.com/1",
+                officiele_titel="title",
+                creatiedatum="2024-10-17",
+            )
+            concept_document = DocumentFactory.create(
+                publicatie=publication,
+                publicatiestatus=PublicationStatusOptions.concept,
+            )
+            revoked_document = DocumentFactory.create(
+                publicatie=publication,
+                publicatiestatus=PublicationStatusOptions.revoked,
+            )
+
+        reverse_url = reverse(
+            "admin:publications_publication_change",
+            kwargs={"object_id": publication.id},
+        )
+
+        response = self.app.get(reverse_url, user=self.user)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(TimelineLogProxy.objects.count(), 1)
+
+        with self.subTest("read audit logging"):
+            log = TimelineLogProxy.objects.get()
+
+            expected_data = {
+                "event": Events.read,
+                "acting_user": {
+                    "identifier": self.user.id,
+                    "display_name": self.user.get_full_name(),
+                },
+                "_cached_object_repr": "title one",
+            }
+
+            self.assertEqual(log.extra_data, expected_data)
+
+        form = response.forms["publication_form"]
+        form["publicatiestatus"].select(text=PublicationStatusOptions.revoked.label)
+
+        with freeze_time("2024-09-28T00:14:00-00:00"):
+            response = form.submit(name="_save")
+
+        self.assertEqual(response.status_code, 302)
+
+        publication.refresh_from_db()
+        published_document.refresh_from_db()
+        concept_document.refresh_from_db()
+        revoked_document.refresh_from_db()
+
+        self.assertEqual(TimelineLogProxy.objects.count(), 3)
+
+        with self.subTest("update publication audit logging"):
+            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore reportAttributeAccessIssue
+                publication
+            ).get(
+                extra_data__event=Events.update
+            )
+
+            expected_data = {
+                "event": Events.update,
+                "acting_user": {
+                    "identifier": self.user.id,
+                    "display_name": self.user.get_full_name(),
+                },
+                "object_data": {
+                    "id": publication.pk,
+                    "informatie_categorieen": [ic.pk, ic2.pk],
+                    "laatst_gewijzigd_datum": "2024-09-28T00:14:00Z",
+                    "officiele_titel": "title one",
+                    "omschrijving": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                    "opsteller": organisation.pk,
+                    "publicatiestatus": PublicationStatusOptions.revoked,
+                    "publisher": organisation.pk,
+                    "registratiedatum": "2024-09-27T00:14:00Z",
+                    "uuid": str(publication.uuid),
+                    "verantwoordelijke": organisation.pk,
+                    "verkorte_titel": "one",
+                },
+                "_cached_object_repr": "title one",
+            }
+
+            self.assertEqual(update_publication_log.extra_data, expected_data)
+
+        with self.subTest("update document audit logging"):
+            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore reportAttributeAccessIssue
+                published_document
+            ).get()
+
+            expected_data = {
+                "event": Events.update,
+                "acting_user": {
+                    "identifier": self.user.id,
+                    "display_name": self.user.get_full_name(),
+                },
+                "object_data": {
+                    "id": published_document.pk,
+                    "lock": "",
+                    "uuid": str(published_document.uuid),
+                    "identifier": "http://example.com/1",
+                    "publicatie": publication.id,
+                    "publicatiestatus": PublicationStatusOptions.revoked,
+                    "bestandsnaam": "unknown.bin",
+                    "creatiedatum": "2024-10-17",
+                    "omschrijving": "",
+                    "document_uuid": None,
+                    "bestandsomvang": 0,
+                    "verkorte_titel": "",
+                    "bestandsformaat": "unknown",
+                    "officiele_titel": "title",
+                    "document_service": None,
+                    "registratiedatum": "2024-09-27T00:14:00Z",
+                    "laatst_gewijzigd_datum": "2024-09-28T00:14:00Z",
+                },
+                "_cached_object_repr": "title",
+            }
+
+            self.assertEqual(update_publication_log.extra_data, expected_data)
+
     def test_admin_delete(self):
         assert not TimelineLogProxy.objects.exists()
         information_category = InformationCategoryFactory.create()

--- a/src/woo_publications/publications/tests/test_api_logging.py
+++ b/src/woo_publications/publications/tests/test_api_logging.py
@@ -212,7 +212,7 @@ class PublicationLoggingTests(TokenAuthMixin, APITestCase):
         self.assertEqual(TimelineLogProxy.objects.count(), 2)
 
         with self.subTest("update publication audit logging"):
-            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore reportAttributeAccessIssue
+            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore[reportAttributeAccessIssue]
                 publication
             ).get(
                 extra_data__event=Events.update
@@ -242,7 +242,7 @@ class PublicationLoggingTests(TokenAuthMixin, APITestCase):
             self.assertEqual(update_publication_log.extra_data, expected_data)
 
         with self.subTest("update document audit logging"):
-            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore reportAttributeAccessIssue
+            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore[reportAttributeAccessIssue]
                 published_document
             ).get()
 

--- a/src/woo_publications/publications/tests/test_api_logging.py
+++ b/src/woo_publications/publications/tests/test_api_logging.py
@@ -159,6 +159,121 @@ class PublicationLoggingTests(TokenAuthMixin, APITestCase):
 
         self.assertEqual(log.extra_data, expected_data)
 
+    def test_partial_update_publication_status_to_revoked_also_revokes_published_documents(
+        self,
+    ):
+        assert not TimelineLogProxy.objects.exists()
+        ic, ic2 = InformationCategoryFactory.create_batch(2)
+        organisation = OrganisationFactory.create(is_actief=True)
+        with freeze_time("2024-09-27T00:14:00-00:00"):
+            publication = PublicationFactory.create(
+                publisher=organisation,
+                verantwoordelijke=organisation,
+                opsteller=organisation,
+                informatie_categorieen=[ic, ic2],
+                officiele_titel="title one",
+                verkorte_titel="one",
+                omschrijving="Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            )
+            published_document = DocumentFactory.create(
+                publicatie=publication,
+                publicatiestatus=PublicationStatusOptions.published,
+                identifier="http://example.com/1",
+                officiele_titel="title",
+                creatiedatum="2024-10-17",
+            )
+            concept_document = DocumentFactory.create(
+                publicatie=publication,
+                publicatiestatus=PublicationStatusOptions.concept,
+            )
+            revoked_document = DocumentFactory.create(
+                publicatie=publication,
+                publicatiestatus=PublicationStatusOptions.revoked,
+            )
+
+        detail_url = reverse(
+            "api:publication-detail",
+            kwargs={"uuid": str(publication.uuid)},
+        )
+        data = {
+            "publicatiestatus": PublicationStatusOptions.revoked,
+        }
+
+        with freeze_time("2024-09-28T00:14:00-00:00"):
+            response = self.client.patch(detail_url, data, headers=AUDIT_HEADERS)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        publication.refresh_from_db()
+        published_document.refresh_from_db()
+        concept_document.refresh_from_db()
+        revoked_document.refresh_from_db()
+
+        self.assertEqual(TimelineLogProxy.objects.count(), 2)
+
+        with self.subTest("update publication audit logging"):
+            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore reportAttributeAccessIssue
+                publication
+            ).get(
+                extra_data__event=Events.update
+            )
+
+            expected_data = {
+                "event": Events.update,
+                "remarks": "remark",
+                "acting_user": {"identifier": "id", "display_name": "username"},
+                "object_data": {
+                    "id": publication.pk,
+                    "informatie_categorieen": [ic.pk, ic2.pk],
+                    "laatst_gewijzigd_datum": "2024-09-28T00:14:00Z",
+                    "officiele_titel": "title one",
+                    "omschrijving": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                    "opsteller": organisation.pk,
+                    "publicatiestatus": PublicationStatusOptions.revoked,
+                    "publisher": organisation.pk,
+                    "registratiedatum": "2024-09-27T00:14:00Z",
+                    "uuid": str(publication.uuid),
+                    "verantwoordelijke": organisation.pk,
+                    "verkorte_titel": "one",
+                },
+                "_cached_object_repr": "title one",
+            }
+
+            self.assertEqual(update_publication_log.extra_data, expected_data)
+
+        with self.subTest("update document audit logging"):
+            update_publication_log = TimelineLogProxy.objects.for_object(  # pyright: ignore reportAttributeAccessIssue
+                published_document
+            ).get()
+
+            expected_data = {
+                "event": Events.update,
+                "remarks": "remark",
+                "acting_user": {"identifier": "id", "display_name": "username"},
+                "object_data": {
+                    "id": published_document.pk,
+                    "lock": "",
+                    "uuid": str(published_document.uuid),
+                    "identifier": "http://example.com/1",
+                    "publicatie": publication.id,
+                    "publicatiestatus": PublicationStatusOptions.revoked,
+                    "bestandsnaam": "unknown.bin",
+                    "creatiedatum": "2024-10-17",
+                    "omschrijving": "",
+                    "document_uuid": None,
+                    "bestandsomvang": 0,
+                    "verkorte_titel": "",
+                    "bestandsformaat": "unknown",
+                    "officiele_titel": "title",
+                    "document_service": None,
+                    "registratiedatum": "2024-09-27T00:14:00Z",
+                    "laatst_gewijzigd_datum": "2024-09-28T00:14:00Z",
+                },
+                "_cached_object_repr": "title",
+            }
+
+            self.assertEqual(update_publication_log.extra_data, expected_data)
+
     def test_destroy_publication(self):
         assert not TimelineLogProxy.objects.exists()
         ic = InformationCategoryFactory.create()

--- a/src/woo_publications/publications/tests/test_publications_admin.py
+++ b/src/woo_publications/publications/tests/test_publications_admin.py
@@ -13,7 +13,7 @@ from woo_publications.metadata.tests.factories import (
 
 from ..constants import PublicationStatusOptions
 from ..models import Publication
-from .factories import PublicationFactory
+from .factories import DocumentFactory, PublicationFactory
 
 
 @disable_admin_mfa()
@@ -343,6 +343,55 @@ class TestPublicationsAdmin(WebTest):
             self.assertEqual(
                 str(publication.laatst_gewijzigd_datum), "2024-09-27 00:14:00+00:00"
             )
+
+    def test_publications_when_revoking_publication_the_published_documents_also_get_revoked(
+        self,
+    ):
+        ic = InformationCategoryFactory.create()
+        publication = PublicationFactory.create(
+            informatie_categorieen=[ic],
+            publicatiestatus=PublicationStatusOptions.published,
+        )
+        published_document = DocumentFactory.create(
+            publicatie=publication, publicatiestatus=PublicationStatusOptions.published
+        )
+        concept_document = DocumentFactory.create(
+            publicatie=publication, publicatiestatus=PublicationStatusOptions.concept
+        )
+        revoked_document = DocumentFactory.create(
+            publicatie=publication, publicatiestatus=PublicationStatusOptions.revoked
+        )
+
+        reverse_url = reverse(
+            "admin:publications_publication_change",
+            kwargs={"object_id": publication.id},
+        )
+
+        response = self.app.get(reverse_url, user=self.user)
+
+        self.assertEqual(response.status_code, 200)
+
+        form = response.forms["publication_form"]
+        form["publicatiestatus"].select(text=PublicationStatusOptions.revoked.label)
+        response = form.submit(name="_save")
+
+        self.assertEqual(response.status_code, 302)
+
+        publication.refresh_from_db()
+        published_document.refresh_from_db()
+        concept_document.refresh_from_db()
+        revoked_document.refresh_from_db()
+
+        self.assertEqual(publication.publicatiestatus, PublicationStatusOptions.revoked)
+        self.assertEqual(
+            published_document.publicatiestatus, PublicationStatusOptions.revoked
+        )
+        self.assertEqual(
+            concept_document.publicatiestatus, PublicationStatusOptions.concept
+        )
+        self.assertEqual(
+            revoked_document.publicatiestatus, PublicationStatusOptions.revoked
+        )
 
     def test_publications_admin_not_allowed_to_update_when_publication_is_revoked(self):
         ic = InformationCategoryFactory.create()

--- a/src/woo_publications/typing.py
+++ b/src/woo_publications/typing.py
@@ -1,3 +1,7 @@
+from typing import TypedDict
+
 type JSONPrimitive = str | int | float | bool | None
 type JSONValue = JSONPrimitive | JSONObject | list[JSONValue]
 type JSONObject = dict[str, JSONValue]
+
+ApiUser = TypedDict("ApiUser", {"user_id": str, "user_repr": str})

--- a/src/woo_publications/typing.py
+++ b/src/woo_publications/typing.py
@@ -1,7 +1,3 @@
-from typing import TypedDict
-
 type JSONPrimitive = str | int | float | bool | None
 type JSONValue = JSONPrimitive | JSONObject | list[JSONValue]
 type JSONObject = dict[str, JSONValue]
-
-ApiUser = TypedDict("ApiUser", {"user_id": str, "user_repr": str})


### PR DESCRIPTION
Fixes #64

**Changes**

- added model function to revoke the published documents of a publication when it gets revoked.
- linked the func to the admin
- linked the func to the api
