### PR TITLE
Changed organisation admin fields for publication

### DIFF
--- a/src/woo_publications/publications/admin.py
+++ b/src/woo_publications/publications/admin.py
@@ -37,6 +37,11 @@ class PublicationAdmin(AdminAuditLogMixin, admin.ModelAdmin):
         "show_actions",
     )
     autocomplete_fields = ("informatie_categorieen",)
+    raw_id_fields = (
+        "publisher",
+        "verantwoordelijke",
+        "opsteller",
+    )
     readonly_fields = (
         "uuid",
         "registratiedatum",

--- a/src/woo_publications/publications/tests/test_admin_logging.py
+++ b/src/woo_publications/publications/tests/test_admin_logging.py
@@ -53,9 +53,9 @@ class TestPublicationAdminAuditLogging(WebTest):
         # Force the value because the select box options get loaded in with js
         form["informatie_categorieen"].force_value([ic.id, ic2.id])
         form["publicatiestatus"].select(text=PublicationStatusOptions.concept.label)
-        form["publisher"].select(text=organisation.naam)
-        form["verantwoordelijke"].select(text=organisation.naam)
-        form["opsteller"].select(text=organisation2.naam)
+        form["publisher"] = str(organisation.pk)
+        form["verantwoordelijke"] = str(organisation.pk)
+        form["opsteller"] = str(organisation2.pk)
         form["officiele_titel"] = "The official title of this publication"
         form["verkorte_titel"] = "The title"
         form["omschrijving"] = (
@@ -122,9 +122,9 @@ class TestPublicationAdminAuditLogging(WebTest):
         form = response.forms["publication_form"]
         form["informatie_categorieen"].select_multiple(texts=[ic.naam])
         form["publicatiestatus"].select(text=PublicationStatusOptions.concept.label)
-        form["publisher"].select(text=organisation2.naam)
-        form["verantwoordelijke"].select(text=organisation2.naam)
-        form["opsteller"].select(text=organisation2.naam)
+        form["publisher"] = str(organisation2.pk)
+        form["verantwoordelijke"] = str(organisation2.pk)
+        form["opsteller"] = str(organisation2.pk)
         form["officiele_titel"] = "changed official title"
         form["verkorte_titel"] = "changed short title"
         form["omschrijving"] = "changed description"

--- a/src/woo_publications/publications/tests/test_publications_admin.py
+++ b/src/woo_publications/publications/tests/test_publications_admin.py
@@ -200,9 +200,9 @@ class TestPublicationsAdmin(WebTest):
             # Force the value because the select box options get loaded in with js
             form["informatie_categorieen"].force_value([ic.id, ic2.id, ic3.id])
             form["publicatiestatus"].select(text=PublicationStatusOptions.concept.label)
-            form["publisher"].select(text=organisation.naam)
-            form["verantwoordelijke"].select(text=organisation.naam)
-            form["opsteller"].select(text=organisation.naam)
+            form["publisher"] = str(organisation.pk)
+            form["verantwoordelijke"] = str(organisation.pk)
+            form["opsteller"] = str(organisation.pk)
             form["officiele_titel"] = "The official title of this publication"
             form["verkorte_titel"] = "The title"
             form["omschrijving"] = (
@@ -314,9 +314,9 @@ class TestPublicationsAdmin(WebTest):
         with self.subTest("complete data updates publication"):
             form["informatie_categorieen"].select_multiple(texts=[ic.naam])
             form["publicatiestatus"].select(text=PublicationStatusOptions.concept.label)
-            form["publisher"].select(text=organisation2.naam)
-            form["verantwoordelijke"].select(text=organisation2.naam)
-            form["opsteller"].select(text=organisation2.naam)
+            form["publisher"] = str(organisation2.pk)
+            form["verantwoordelijke"] = str(organisation2.pk)
+            form["opsteller"] = str(organisation2.pk)
             form["officiele_titel"] = "changed official title"
             form["verkorte_titel"] = "changed short title"
             form["omschrijving"] = "changed description"


### PR DESCRIPTION
Fixes #66

**Changes**

Changed organisation fields in the admin to raw_id_fields and updated the tests.

