### PR TITLE
:sparkles: [#133] Implement streaming/downloading file content

### DIFF
--- a/src/woo_publications/api/exceptions.py
+++ b/src/woo_publications/api/exceptions.py
@@ -1,0 +1,9 @@
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class BadGateway(APIException):
+    status_code = status.HTTP_502_BAD_GATEWAY
+    default_detail = _("Bad gateway.")

--- a/src/woo_publications/api/openapi.yaml
+++ b/src/woo_publications/api/openapi.yaml
@@ -285,6 +285,71 @@ paths:
               schema:
                 $ref: '#/components/schemas/DocumentStatus'
           description: ''
+  /api/v1/documenten/{uuid}/download:
+    get:
+      operationId: documentenDownloadRetrieve
+      description: |-
+        Download the binary content of the document. The endpoint does not return JSON data, but instead the file content is streamed.
+
+        You can only download the content of files that are completely uploaded in the upstream API.
+      summary: Download the binary file contents
+      parameters:
+      - in: header
+        name: Audit-Remarks
+        schema:
+          type: string
+        description: |2
+
+          Any additional information describing the action performed by the user.
+        required: true
+      - in: header
+        name: Audit-User-ID
+        schema:
+          type: string
+        description: |2
+
+          The system identifier that uniquely identifies the user performing the action.
+          Ideally, this is obtained from some Identity and Access Management infrastructure.
+          With OpenID Connect, this would typically be the `sub` claim.
+        required: true
+      - in: header
+        name: Audit-User-Representation
+        schema:
+          type: string
+        description: |2
+
+          The display name of the user performing the action, to make them recognizable.
+        required: true
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - Documenten
+      security:
+      - tokenAuth: []
+      responses:
+        '200':
+          headers:
+            Content-Length:
+              schema:
+                type: string
+              description: Total size in bytes of the download.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: The binary file contents.
+        '502':
+          headers:
+            Content-Length:
+              schema:
+                type: string
+              description: Total size in bytes of the download.
+          description: Bad gateway - failure to stream content.
   /api/v1/informatiecategorieen:
     get:
       operationId: informatiecategorieenList

--- a/src/woo_publications/logging/constants.py
+++ b/src/woo_publications/logging/constants.py
@@ -9,4 +9,4 @@ class Events(models.TextChoices):
     update = "update", _("Record updated")
     delete = "delete", _("Record deleted")
     # Specific events
-    ...
+    download = "download", _("Downloaded")

--- a/src/woo_publications/logging/logevent.py
+++ b/src/woo_publications/logging/logevent.py
@@ -20,6 +20,7 @@ __all__ = [
     "audit_api_read",
     "audit_api_update",
     "audit_api_delete",
+    "audit_api_download",
 ]
 
 
@@ -200,5 +201,22 @@ def audit_api_delete(
         user_display=user_display,
         django_user=None,
         object_data=object_data,
+        remarks=remarks,
+    )
+
+
+def audit_api_download(
+    *,
+    content_object: models.Model,
+    user_id: str,
+    user_display: str,
+    remarks: str,
+) -> None:
+    _audit_event(
+        content_object=content_object,
+        event=Events.download,
+        user_id=user_id,
+        user_display=user_display,
+        django_user=None,
         remarks=remarks,
     )

--- a/src/woo_publications/logging/service.py
+++ b/src/woo_publications/logging/service.py
@@ -14,6 +14,7 @@ from .logevent import (
     audit_admin_update,
     audit_api_create,
     audit_api_delete,
+    audit_api_download,
     audit_api_read,
     audit_api_update,
 )
@@ -41,4 +42,5 @@ __all__ = [
     "audit_api_read",
     "audit_api_update",
     "audit_api_delete",
+    "audit_api_download",
 ]

--- a/src/woo_publications/publications/models.py
+++ b/src/woo_publications/publications/models.py
@@ -33,6 +33,7 @@ _DOCUMENT_SET = ~models.Q(document_service=None) & ~models.Q(document_uuid=None)
 
 
 class Publication(models.Model):
+    id: int  # implicitly provided by django
     uuid = models.UUIDField(
         _("UUID"),
         unique=True,
@@ -179,6 +180,7 @@ class Publication(models.Model):
 
 
 class Document(models.Model):
+    id: int  # implicitly provided by django
     uuid = models.UUIDField(
         _("UUID"),
         unique=True,

--- a/src/woo_publications/publications/tests/factories.py
+++ b/src/woo_publications/publications/tests/factories.py
@@ -9,7 +9,7 @@ from woo_publications.metadata.tests.factories import OrganisationFactory
 from ..models import Document, Publication
 
 
-class PublicationFactory(factory.django.DjangoModelFactory):
+class PublicationFactory(factory.django.DjangoModelFactory[Publication]):
     publisher = factory.SubFactory(OrganisationFactory, is_actief=True)
     officiele_titel = factory.Faker("word")
 
@@ -30,7 +30,7 @@ class PublicationFactory(factory.django.DjangoModelFactory):
             obj.informatie_categorieen.set(extracted)
 
 
-class DocumentFactory(factory.django.DjangoModelFactory):
+class DocumentFactory(factory.django.DjangoModelFactory[Document]):
     publicatie = factory.SubFactory(PublicationFactory)
     identifier = factory.Sequence(lambda n: f"document-{n}")
     officiele_titel = factory.Faker("word")

--- a/src/woo_publications/publications/tests/vcr_cassettes/test_document_api_endpoints/DocumentDownloadTests/test_download_document.yaml
+++ b/src/woo_publications/publications/tests/vcr_cassettes/test_document_api_endpoints/DocumentDownloadTests/test_download_document.yaml
@@ -1,0 +1,244 @@
+interactions:
+- request:
+    body: '{"identificatie": "fffef0e5-3e37-40a1-98dc-14397b3f27d8", "bronorganisatie":
+      "000000000", "informatieobjecttype": "http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8",
+      "creatiedatum": "2024-11-08", "titel": "white", "auteur": "GPP-Woo/ODRC", "status":
+      "definitief", "formaat": "application/octet-stream", "taal": "dut", "bestandsnaam":
+      "unknown.bin", "inhoud": null, "bestandsomvang": 5, "beschrijving": "", "indicatieGebruiksrecht":
+      false}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTQ5OTU4NywiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.X1RLc1_Y3kdlaacJmLvtDkmoQpQLp3e1ziNdtYvx8Vg
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '497'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten
+  response:
+    body:
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/8c8e4f4b-0ec0-44ef-abee-6aff1b70b1c1","identificatie":"fffef0e5-3e37-40a1-98dc-14397b3f27d8","bronorganisatie":"000000000","creatiedatum":"2024-11-08","titel":"white","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/ODRC","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2024-11-13T12:06:27.744592Z","bestandsnaam":"unknown.bin","inhoud":null,"bestandsomvang":5,"link":"","beschrijving":"","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8","locked":true,"bestandsdelen":[{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/544fac05-e428-4080-a2cd-f74890eb4ffc","volgnummer":1,"omvang":5,"voltooid":false,"lock":"62088f14f5a34635a7b0d7506ab66546"}],"trefwoorden":[],"lock":"62088f14f5a34635a7b0d7506ab66546"}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1166'
+      Content-Security-Policy:
+      - default-src 'self'; form-action 'self'; script-src 'self'; object-src 'none';
+        frame-src 'self'; base-uri 'self'; frame-ancestors 'none'; img-src 'self';
+        style-src 'self'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/8c8e4f4b-0ec0-44ef-abee-6aff1b70b1c1
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: "--f7b6ca3652bae57b6365e78a84aa7861\r\nContent-Disposition: form-data; name=\"lock\"\r\n\r\n62088f14f5a34635a7b0d7506ab66546\r\n--f7b6ca3652bae57b6365e78a84aa7861\r\nContent-Disposition:
+      form-data; name=\"inhoud\"; filename=\"dummy.txt\"\r\n\r\naAaAa\r\n--f7b6ca3652bae57b6365e78a84aa7861--\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTQ5OTU4NywiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.X1RLc1_Y3kdlaacJmLvtDkmoQpQLp3e1ziNdtYvx8Vg
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '269'
+      Content-Type:
+      - multipart/form-data; boundary=f7b6ca3652bae57b6365e78a84aa7861
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/544fac05-e428-4080-a2cd-f74890eb4ffc
+  response:
+    body:
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/544fac05-e428-4080-a2cd-f74890eb4ffc","volgnummer":1,"omvang":5,"voltooid":true,"lock":"62088f14f5a34635a7b0d7506ab66546"}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - PUT, OPTIONS
+      Content-Length:
+      - '199'
+      Content-Security-Policy:
+      - default-src 'self'; form-action 'self'; script-src 'self'; object-src 'none';
+        frame-src 'self'; base-uri 'self'; frame-ancestors 'none'; img-src 'self';
+        style-src 'self'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTQ5OTU4NywiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.X1RLc1_Y3kdlaacJmLvtDkmoQpQLp3e1ziNdtYvx8Vg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/8c8e4f4b-0ec0-44ef-abee-6aff1b70b1c1
+  response:
+    body:
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/8c8e4f4b-0ec0-44ef-abee-6aff1b70b1c1","identificatie":"fffef0e5-3e37-40a1-98dc-14397b3f27d8","bronorganisatie":"000000000","creatiedatum":"2024-11-08","titel":"white","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/ODRC","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2024-11-13T12:06:27.744592Z","bestandsnaam":"unknown.bin","inhoud":null,"bestandsomvang":5,"link":"","beschrijving":"","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8","locked":true,"bestandsdelen":[{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/544fac05-e428-4080-a2cd-f74890eb4ffc","volgnummer":1,"omvang":5,"voltooid":true,"lock":"62088f14f5a34635a7b0d7506ab66546"}],"trefwoorden":[]}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1123'
+      Content-Security-Policy:
+      - default-src 'self'; form-action 'self'; script-src 'self'; object-src 'none';
+        frame-src 'self'; base-uri 'self'; frame-ancestors 'none'; img-src 'self';
+        style-src 'self'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"5ad03efc898fcab7d7dc5cef5a5fe002"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"lock": "62088f14f5a34635a7b0d7506ab66546"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTQ5OTU4NywiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.X1RLc1_Y3kdlaacJmLvtDkmoQpQLp3e1ziNdtYvx8Vg
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/8c8e4f4b-0ec0-44ef-abee-6aff1b70b1c1/unlock
+  response:
+    body:
+      string: ''
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - POST, OPTIONS
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; form-action 'self'; script-src 'self'; object-src 'none';
+        frame-src 'self'; base-uri 'self'; frame-ancestors 'none'; img-src 'self';
+        style-src 'self'
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTQ5OTU4NywiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.X1RLc1_Y3kdlaacJmLvtDkmoQpQLp3e1ziNdtYvx8Vg
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/8c8e4f4b-0ec0-44ef-abee-6aff1b70b1c1/download
+  response:
+    body:
+      string: aAaAa
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Disposition:
+      - attachment; filename="unknown_ywLSOri.bin"
+      Content-Security-Policy:
+      - default-src 'self'; form-action 'self'; script-src 'self'; object-src 'none';
+        frame-src 'self'; base-uri 'self'; frame-ancestors 'none'; img-src 'self';
+        style-src 'self'
+      Content-Type:
+      - application/octet-stream
+      Content-length:
+      - '5'
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Last-Modified:
+      - Wed, 13 Nov 2024 12:06:27 GMT
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/woo_publications/publications/tests/vcr_cassettes/test_document_api_endpoints/DocumentDownloadTests/test_download_incomplete_document.yaml
+++ b/src/woo_publications/publications/tests/vcr_cassettes/test_document_api_endpoints/DocumentDownloadTests/test_download_incomplete_document.yaml
@@ -1,0 +1,101 @@
+interactions:
+- request:
+    body: '{"identificatie": "9c0a3198-c88e-4fd1-ba12-9ffe716c199e", "bronorganisatie":
+      "000000000", "informatieobjecttype": "http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8",
+      "creatiedatum": "2024-10-14", "titel": "reveal", "auteur": "GPP-Woo/ODRC", "status":
+      "definitief", "formaat": "application/octet-stream", "taal": "dut", "bestandsnaam":
+      "unknown.bin", "inhoud": null, "bestandsomvang": 5, "beschrijving": "", "indicatieGebruiksrecht":
+      false}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTUwMjM0NywiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.3NgXOS8SzC_tNBoFJqYzV9ODvVjCSs5RZ3QAeHAJfCQ
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '498'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten
+  response:
+    body:
+      string: '{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/1e2c063b-e16f-4775-b64b-84b7a7b3b085","identificatie":"9c0a3198-c88e-4fd1-ba12-9ffe716c199e","bronorganisatie":"000000000","creatiedatum":"2024-10-14","titel":"reveal","vertrouwelijkheidaanduiding":"openbaar","auteur":"GPP-Woo/ODRC","status":"definitief","formaat":"application/octet-stream","taal":"dut","versie":1,"beginRegistratie":"2024-11-13T12:52:29.157061Z","bestandsnaam":"unknown.bin","inhoud":null,"bestandsomvang":5,"link":"","beschrijving":"","ontvangstdatum":null,"verzenddatum":null,"indicatieGebruiksrecht":false,"verschijningsvorm":"","ondertekening":{"soort":"","datum":null},"integriteit":{"algoritme":"","waarde":"","datum":null},"informatieobjecttype":"http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/9aeb7501-3f77-4f36-8c8f-d21f47c2d6e8","locked":true,"bestandsdelen":[{"url":"http://openzaak.docker.internal:8001/documenten/api/v1/bestandsdelen/5fe58ab3-27bd-4975-8f61-e1e196569b93","volgnummer":1,"omvang":5,"voltooid":false,"lock":"a7972f4d6c8d486989467da5c9038621"}],"trefwoorden":[],"lock":"a7972f4d6c8d486989467da5c9038621"}'
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1167'
+      Content-Security-Policy:
+      - frame-src 'self'; frame-ancestors 'none'; style-src 'self'; script-src 'self';
+        base-uri 'self'; default-src 'self'; img-src 'self'; form-action 'self'; object-src
+        'none'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/1e2c063b-e16f-4775-b64b-84b7a7b3b085
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ3b28tcHVibGljYXRpb25zLWRldiIsImlhdCI6MTczMTUwMjM0OSwiY2xpZW50X2lkIjoid29vLXB1YmxpY2F0aW9ucy1kZXYiLCJ1c2VyX2lkIjoiIiwidXNlcl9yZXByZXNlbnRhdGlvbiI6IiJ9.7q_O1vebUMjdxEYL7UnJhc0ybmqd243dKUC8w55WqoE
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: http://openzaak.docker.internal:8001/documenten/api/v1/enkelvoudiginformatieobjecten/1e2c063b-e16f-4775-b64b-84b7a7b3b085/download
+  response:
+    body:
+      string: application/octet-stream
+    headers:
+      API-version:
+      - 1.4.2
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '24'
+      Content-Security-Policy:
+      - frame-src 'self'; frame-ancestors 'none'; style-src 'self'; script-src 'self';
+        base-uri 'self'; default-src 'self'; img-src 'self'; form-action 'self'; object-src
+        'none'
+      Content-Type:
+      - application/octet-stream
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1


### PR DESCRIPTION
Fixes #133

**Changes**

* The binary content of the uploaded document is streamed down directly from the upstream Documenten API.
* Upstream errors are transformed into HTTP 502 errors on our end
* Downloads are audit logged

