### PR TITLE
Ignore file parts on regular read ops

### DIFF
--- a/src/woo_publications/publications/models.py
+++ b/src/woo_publications/publications/models.py
@@ -336,9 +336,10 @@ class Document(models.Model):
         if not (self.document_service and self.document_uuid):
             return None
 
-        raise NotImplementedError(
-            "Dynamically retrieving the 'zgw_document' is not yet implemented."
-        )
+        # at this time we do not dynamically look up the object in the upstream API,
+        # since evaluating this property in API detail/list responses adds significant
+        # overhead.
+        return None
 
     @zgw_document.setter
     def zgw_document(self, document: ZGWDocument) -> None:

--- a/src/woo_publications/publications/tests/test_document_api_endpoints.py
+++ b/src/woo_publications/publications/tests/test_document_api_endpoints.py
@@ -477,7 +477,7 @@ class DocumentApiReadTests(TokenAuthMixin, APITestCase):
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             # avoid hitting the documenten API for list endpoints
-            self.assertEqual(response.json()["results"][0]["bestandsdelen"], [])
+            self.assertIsNone(response.json()["results"][0]["bestandsdelen"])
 
         with self.subTest("detail endpoint"):
             detail_url = reverse(
@@ -489,7 +489,7 @@ class DocumentApiReadTests(TokenAuthMixin, APITestCase):
 
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             # avoid hitting the documenten API for retrieve operations
-            self.assertEqual(response.json()["bestandsdelen"], [])
+            self.assertIsNone(response.json()["bestandsdelen"])
 
 
 @override_settings(ALLOWED_HOSTS=["testserver", "host.docker.internal"])

--- a/src/woo_publications/publications/tests/test_document_api_endpoints.py
+++ b/src/woo_publications/publications/tests/test_document_api_endpoints.py
@@ -467,6 +467,30 @@ class DocumentApiReadTests(TokenAuthMixin, APITestCase):
 
         self.assertEqual(data, expected_data)
 
+    def test_read_endpoints_document_registered_in_documenten_api(self):
+        document = DocumentFactory.create(with_registered_document=True)
+
+        with self.subTest("list endpoint"):
+            endpoint = reverse("api:document-list")
+
+            response = self.client.get(endpoint, headers=AUDIT_HEADERS)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            # avoid hitting the documenten API for list endpoints
+            self.assertEqual(response.json()["results"][0]["bestandsdelen"], [])
+
+        with self.subTest("detail endpoint"):
+            detail_url = reverse(
+                "api:document-detail",
+                kwargs={"uuid": str(document.uuid)},
+            )
+
+            response = self.client.get(detail_url, headers=AUDIT_HEADERS)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            # avoid hitting the documenten API for retrieve operations
+            self.assertEqual(response.json()["bestandsdelen"], [])
+
 
 @override_settings(ALLOWED_HOSTS=["testserver", "host.docker.internal"])
 class DocumentApiCreateTests(VCRMixin, TokenAuthMixin, APITestCase):


### PR DESCRIPTION
Reported by Armijn during testing, traceback/error info available on Sentry.
