### PR TITLE
Feature/68 publication filters

### DIFF
--- a/src/woo_publications/api/openapi.yaml
+++ b/src/woo_publications/api/openapi.yaml
@@ -801,8 +801,10 @@ paths:
           items:
             type: string
             format: uuid
-        description: Filter publications based on information category/categories
-          UUID (UUIDs should be seperated by commas).
+        description: |-
+          Filter publications that belong to a particular information category. When you specify multiple categories, publications belonging to any category are returned.
+
+          Filter values should be the UUID of the categories.
         explode: true
         style: form
       - name: page
@@ -827,18 +829,17 @@ paths:
           * `concept` - Concept
           * `ingetrokken` - Revoked
       - in: query
-        name: registratiedatum_Gte
+        name: registratiedatumTot
+        schema:
+          type: string
+          format: date-time
+        description: Filter publications that were registered before the given value.
+      - in: query
+        name: registratiedatumVanaf
         schema:
           type: string
           format: date-time
         description: Filter publications that were registered after or on the given
-          value.
-      - in: query
-        name: registratiedatum_Lte
-        schema:
-          type: string
-          format: date-time
-        description: Filter publications that were registered before or on the given
           value.
       - in: query
         name: search

--- a/src/woo_publications/api/openapi.yaml
+++ b/src/woo_publications/api/openapi.yaml
@@ -794,6 +794,17 @@ paths:
         schema:
           type: string
         description: Filter publicaties op basis van de identificatie van de eigenaar.
+      - in: query
+        name: informatieCategorieen
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+        description: Filter publications based on information category/categories
+          UUID (UUIDs should be seperated by commas).
+        explode: true
+        style: form
       - name: page
         required: false
         in: query
@@ -815,6 +826,25 @@ paths:
           * `gepubliceerd` - Published
           * `concept` - Concept
           * `ingetrokken` - Revoked
+      - in: query
+        name: registratiedatum_Gte
+        schema:
+          type: string
+          format: date-time
+        description: Filter publications that were registered after or on the given
+          value.
+      - in: query
+        name: registratiedatum_Lte
+        schema:
+          type: string
+          format: date-time
+        description: Filter publications that were registered before or on the given
+          value.
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: Searches publications based on the official and short title.
       - in: query
         name: sorteer
         schema:

--- a/src/woo_publications/conf/ci.py
+++ b/src/woo_publications/conf/ci.py
@@ -1,6 +1,8 @@
 import os
 import warnings
 
+from django.core.paginator import UnorderedObjectListWarning
+
 os.environ.setdefault("IS_HTTPS", "no")
 os.environ.setdefault("SECRET_KEY", "for-testing-purposes-only")
 os.environ.setdefault("LOG_REQUESTS", "no")
@@ -38,4 +40,12 @@ warnings.filterwarnings(
     r"DateTimeField .* received a naive datetime",
     RuntimeWarning,
     r"django\.db\.models\.fields",
+)
+
+# querysets in api viewsets *must* be ordered
+warnings.filterwarnings(
+    "error",
+    r"Pagination may yield inconsistent results with an unordered object_list: .*",
+    UnorderedObjectListWarning,
+    r"rest_framework\.pagination",
 )

--- a/src/woo_publications/conf/dev.py
+++ b/src/woo_publications/conf/dev.py
@@ -2,6 +2,8 @@ import os
 import sys
 import warnings
 
+from django.core.paginator import UnorderedObjectListWarning
+
 os.environ.setdefault("DEBUG", "yes")
 os.environ.setdefault("ALLOWED_HOSTS", "*")
 os.environ.setdefault(
@@ -101,6 +103,14 @@ warnings.filterwarnings(
     r"DateTimeField .* received a naive datetime",
     RuntimeWarning,
     r"django\.db\.models\.fields",
+)
+
+# querysets in api viewsets *must* be ordered
+warnings.filterwarnings(
+    "error",
+    r"Pagination may yield inconsistent results with an unordered object_list: .*",
+    UnorderedObjectListWarning,
+    r"rest_framework\.pagination",
 )
 
 # Override settings with local settings.

--- a/src/woo_publications/publications/api/filters.py
+++ b/src/woo_publications/publications/api/filters.py
@@ -1,10 +1,13 @@
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
 from django_filters.rest_framework import FilterSet, filters
+from django_filters.widgets import CSVWidget
 
 from woo_publications.logging.constants import Events
 from woo_publications.logging.models import TimelineLogProxy
+from woo_publications.metadata.models import InformationCategory
 
 from ..constants import PublicationStatusOptions
 from ..models import Document, Publication
@@ -47,13 +50,9 @@ class DocumentFilterSet(FilterSet):
 
 
 class PublicationFilterSet(FilterSet):
-    sorteer = filters.OrderingFilter(
-        help_text=_("Order on."),
-        fields=(
-            "registratiedatum",
-            "officiele_titel",
-            "verkorte_titel",
-        ),
+    search = filters.CharFilter(
+        help_text=_("Searches publications based on the official and short title."),
+        method="search_official_and_short_title",
     )
     eigenaar = filters.CharFilter(
         help_text=_("Filter publications based on the owner identifier of the object."),
@@ -63,12 +62,48 @@ class PublicationFilterSet(FilterSet):
         help_text=_("Filter publications based on the publication status."),
         choices=PublicationStatusOptions.choices,
     )
+    registratiedatum__gte = filters.DateTimeFilter(
+        help_text=_(
+            "Filter publications that were registered after or on the given value."
+        ),
+        field_name="registratiedatum",
+        lookup_expr="gte",
+    )
+    registratiedatum__lte = filters.DateTimeFilter(
+        help_text=_(
+            "Filter publications that were registered before or on the given value."
+        ),
+        field_name="registratiedatum",
+        lookup_expr="lte",
+    )
+    informatie_categorieen = filters.ModelMultipleChoiceFilter(
+        help_text=_(
+            "Filter publications based on information category/categories UUID (UUIDs should be seperated by commas)."
+        ),
+        field_name="informatie_categorieen__uuid",
+        to_field_name="uuid",
+        queryset=InformationCategory.objects.all(),
+        widget=CSVWidget(),
+    )
+
+    sorteer = filters.OrderingFilter(
+        help_text=_("Order on."),
+        fields=(
+            "registratiedatum",
+            "officiele_titel",
+            "verkorte_titel",
+        ),
+    )
 
     class Meta:
         model = Publication
         fields = (
+            "search",
             "eigenaar",
             "publicatiestatus",
+            "informatie_categorieen",
+            "registratiedatum__gte",
+            "registratiedatum__lte",
             "sorteer",
         )
 
@@ -82,3 +117,8 @@ class PublicationFilterSet(FilterSet):
         ).values_list("object_id", flat=True)
 
         return queryset.filter(pk__in=[id for id in publication_object_ids])
+
+    def search_official_and_short_title(self, queryset, name: str, value: str):
+        return Publication.objects.filter(
+            Q(officiele_titel__icontains=value) | Q(verkorte_titel__icontains=value)
+        )

--- a/src/woo_publications/publications/api/filters.py
+++ b/src/woo_publications/publications/api/filters.py
@@ -62,23 +62,24 @@ class PublicationFilterSet(FilterSet):
         help_text=_("Filter publications based on the publication status."),
         choices=PublicationStatusOptions.choices,
     )
-    registratiedatum__gte = filters.DateTimeFilter(
+    registratiedatum_vanaf = filters.DateTimeFilter(
         help_text=_(
             "Filter publications that were registered after or on the given value."
         ),
         field_name="registratiedatum",
         lookup_expr="gte",
     )
-    registratiedatum__lte = filters.DateTimeFilter(
-        help_text=_(
-            "Filter publications that were registered before or on the given value."
-        ),
+    registratiedatum_tot = filters.DateTimeFilter(
+        help_text=_("Filter publications that were registered before the given value."),
         field_name="registratiedatum",
-        lookup_expr="lte",
+        lookup_expr="lt",
     )
     informatie_categorieen = filters.ModelMultipleChoiceFilter(
         help_text=_(
-            "Filter publications based on information category/categories UUID (UUIDs should be seperated by commas)."
+            "Filter publications that belong to a particular information category. "
+            "When you specify multiple categories, publications belonging to any "
+            "category are returned.\n\n"
+            "Filter values should be the UUID of the categories."
         ),
         field_name="informatie_categorieen__uuid",
         to_field_name="uuid",
@@ -102,8 +103,8 @@ class PublicationFilterSet(FilterSet):
             "eigenaar",
             "publicatiestatus",
             "informatie_categorieen",
-            "registratiedatum__gte",
-            "registratiedatum__lte",
+            "registratiedatum_vanaf",
+            "registratiedatum_tot",
             "sorteer",
         )
 
@@ -119,6 +120,6 @@ class PublicationFilterSet(FilterSet):
         return queryset.filter(pk__in=[id for id in publication_object_ids])
 
     def search_official_and_short_title(self, queryset, name: str, value: str):
-        return Publication.objects.filter(
+        return queryset.filter(
             Q(officiele_titel__icontains=value) | Q(verkorte_titel__icontains=value)
         )

--- a/src/woo_publications/publications/tests/test_publications_api.py
+++ b/src/woo_publications/publications/tests/test_publications_api.py
@@ -279,6 +279,212 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
             self.assertEqual(data["results"][0], expected_second_item_data)
             self.assertEqual(data["results"][1], expected_first_item_data)
 
+    def test_list_publications_filter_information_categories(self):
+        ic, ic2, ic3 = InformationCategoryFactory.create_batch(3)
+        publication = PublicationFactory.create(informatie_categorieen=[ic])
+        publication2 = PublicationFactory.create(informatie_categorieen=[ic2])
+        publication3 = PublicationFactory.create(informatie_categorieen=[ic2, ic3])
+
+        with self.subTest("filter on a single information category"):
+            response = self.client.get(
+                reverse("api:publication-list"),
+                {"informatie_categorieen": str(ic.uuid)},
+                headers=AUDIT_HEADERS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            data = response.json()
+
+            self.assertEqual(data["count"], 1)
+            self.assertEqual(data["results"][0]["uuid"], str(publication.uuid))
+
+        with self.subTest("filter on multiple information categories "):
+            response = self.client.get(
+                reverse("api:publication-list"),
+                {"informatie_categorieen": f"{ic2.uuid},{ic3.uuid}"},
+                headers=AUDIT_HEADERS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            data = response.json()
+
+            self.assertEqual(data["count"], 2)
+            self.assertEqual(data["results"][0]["uuid"], str(publication3.uuid))
+            self.assertEqual(data["results"][1]["uuid"], str(publication2.uuid))
+
+    def test_list_publications_filter_registratie_datum(self):
+        ic = InformationCategoryFactory.create()
+        with freeze_time("2024-09-24T12:00:00-00:00"):
+            publication = PublicationFactory.create(informatie_categorieen=[ic])
+        with freeze_time("2024-09-25T12:00:00-00:00"):
+            publication2 = PublicationFactory.create(informatie_categorieen=[ic])
+        with freeze_time("2024-09-26T12:00:00-00:00"):
+            publication3 = PublicationFactory.create(informatie_categorieen=[ic])
+
+        with self.subTest("lte specific tests"):
+            with self.subTest("filter on gte date is exact match"):
+                response = self.client.get(
+                    reverse("api:publication-list"),
+                    {"registratiedatum__gte": "2024-09-26T12:00:00-00:00"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(publication3.uuid))
+
+            with self.subTest("filter on gte date is greater then publication"):
+                response = self.client.get(
+                    reverse("api:publication-list"),
+                    {"registratiedatum__gte": "2024-09-26T00:00:00-00:00"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(publication3.uuid))
+
+        with self.subTest("lte specific tests"):
+            with self.subTest("filter on lte date is exact match"):
+                response = self.client.get(
+                    reverse("api:publication-list"),
+                    {"registratiedatum__lte": "2024-09-24T12:00:00-00:00"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(publication.uuid))
+
+            with self.subTest("filter on lte date is lesser then publication"):
+                response = self.client.get(
+                    reverse("api:publication-list"),
+                    {"registratiedatum__lte": "2024-09-25T00:00:00-00:00"},
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(publication.uuid))
+
+        with self.subTest(
+            "filter both lte and gte to find publication between two dates"
+        ):
+            with self.subTest("filter on lte date is lesser then publication"):
+                response = self.client.get(
+                    reverse("api:publication-list"),
+                    {
+                        "registratiedatum__gte": "2024-09-25T00:00:00-00:00",
+                        "registratiedatum__lte": "2024-09-26T00:00:00-00:00",
+                    },
+                    headers=AUDIT_HEADERS,
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.json()
+
+                self.assertEqual(data["count"], 1)
+                self.assertEqual(data["results"][0]["uuid"], str(publication2.uuid))
+
+    def test_list_publications_filter_search(self):
+        ic = InformationCategoryFactory.create()
+        publication = PublicationFactory.create(
+            informatie_categorieen=[ic],
+            officiele_titel="Een prachtige titel met een heleboel woorden.",
+            verkorte_titel="prachtige titel.",
+        )
+        publication2 = PublicationFactory.create(
+            informatie_categorieen=[ic],
+            officiele_titel="Een titel die anders is als de verkorte titel.",
+            verkorte_titel="waarom is deze titel anders.",
+        )
+
+        with self.subTest("officele titel exacte match"):
+            response = self.client.get(
+                reverse("api:publication-list"),
+                {"search": "Een prachtige titel met een heleboel woorden."},
+                headers=AUDIT_HEADERS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            data = response.json()
+
+            self.assertEqual(data["count"], 1)
+            self.assertEqual(data["results"][0]["uuid"], str(publication.uuid))
+
+        with self.subTest("verkorte titel exacte match"):
+            response = self.client.get(
+                reverse("api:publication-list"),
+                {"search": "waarom is deze titel anders."},
+                headers=AUDIT_HEADERS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            data = response.json()
+
+            self.assertEqual(data["count"], 1)
+            self.assertEqual(data["results"][0]["uuid"], str(publication2.uuid))
+
+        with self.subTest("officele titel partial match"):
+            response = self.client.get(
+                reverse("api:publication-list"),
+                {"search": "prachtige titel met"},
+                headers=AUDIT_HEADERS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            data = response.json()
+
+            self.assertEqual(data["count"], 1)
+            self.assertEqual(data["results"][0]["uuid"], str(publication.uuid))
+
+        with self.subTest("verkorte titel partial match"):
+            response = self.client.get(
+                reverse("api:publication-list"),
+                {"search": "deze titel anders"},
+                headers=AUDIT_HEADERS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            data = response.json()
+
+            self.assertEqual(data["count"], 1)
+            self.assertEqual(data["results"][0]["uuid"], str(publication2.uuid))
+
+        with self.subTest("partial match both objects different fields"):
+            response = self.client.get(
+                reverse("api:publication-list"),
+                {"search": "titel."},
+                headers=AUDIT_HEADERS,
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            data = response.json()
+
+            self.assertEqual(data["count"], 2)
+            self.assertEqual(data["results"][0]["uuid"], str(publication.uuid))
+            self.assertEqual(data["results"][1]["uuid"], str(publication2.uuid))
+
     def test_list_publications_filter_owner(self):
         ic, ic2 = InformationCategoryFactory.create_batch(2)
         with freeze_time("2024-09-24T12:00:00-00:00"):

--- a/src/woo_publications/publications/tests/test_publications_api.py
+++ b/src/woo_publications/publications/tests/test_publications_api.py
@@ -280,15 +280,15 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
             self.assertEqual(data["results"][1], expected_first_item_data)
 
     def test_list_publications_filter_information_categories(self):
-        ic, ic2, ic3 = InformationCategoryFactory.create_batch(3)
+        ic, ic2, ic3, ic4 = InformationCategoryFactory.create_batch(4)
         publication = PublicationFactory.create(informatie_categorieen=[ic])
         publication2 = PublicationFactory.create(informatie_categorieen=[ic2])
-        publication3 = PublicationFactory.create(informatie_categorieen=[ic2, ic3])
+        publication3 = PublicationFactory.create(informatie_categorieen=[ic3, ic4])
 
         with self.subTest("filter on a single information category"):
             response = self.client.get(
                 reverse("api:publication-list"),
-                {"informatie_categorieen": str(ic.uuid)},
+                {"informatieCategorieen": str(ic.uuid)},
                 headers=AUDIT_HEADERS,
             )
 
@@ -302,7 +302,7 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
         with self.subTest("filter on multiple information categories "):
             response = self.client.get(
                 reverse("api:publication-list"),
-                {"informatie_categorieen": f"{ic2.uuid},{ic3.uuid}"},
+                {"informatieCategorieen": f"{ic2.uuid},{ic4.uuid}"},
                 headers=AUDIT_HEADERS,
             )
 
@@ -327,7 +327,7 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
             with self.subTest("filter on gte date is exact match"):
                 response = self.client.get(
                     reverse("api:publication-list"),
-                    {"registratiedatum__gte": "2024-09-26T12:00:00-00:00"},
+                    {"registratiedatumVanaf": "2024-09-26T12:00:00-00:00"},
                     headers=AUDIT_HEADERS,
                 )
 
@@ -341,7 +341,7 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
             with self.subTest("filter on gte date is greater then publication"):
                 response = self.client.get(
                     reverse("api:publication-list"),
-                    {"registratiedatum__gte": "2024-09-26T00:00:00-00:00"},
+                    {"registratiedatumVanaf": "2024-09-26T00:00:00-00:00"},
                     headers=AUDIT_HEADERS,
                 )
 
@@ -356,7 +356,7 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
             with self.subTest("filter on lte date is exact match"):
                 response = self.client.get(
                     reverse("api:publication-list"),
-                    {"registratiedatum__lte": "2024-09-24T12:00:00-00:00"},
+                    {"registratiedatumTot": "2024-09-24T12:00:01-00:00"},
                     headers=AUDIT_HEADERS,
                 )
 
@@ -370,7 +370,7 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
             with self.subTest("filter on lte date is lesser then publication"):
                 response = self.client.get(
                     reverse("api:publication-list"),
-                    {"registratiedatum__lte": "2024-09-25T00:00:00-00:00"},
+                    {"registratiedatumTot": "2024-09-25T00:00:00-00:00"},
                     headers=AUDIT_HEADERS,
                 )
 
@@ -388,8 +388,8 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
                 response = self.client.get(
                     reverse("api:publication-list"),
                     {
-                        "registratiedatum__gte": "2024-09-25T00:00:00-00:00",
-                        "registratiedatum__lte": "2024-09-26T00:00:00-00:00",
+                        "registratiedatumVanaf": "2024-09-25T00:00:00-00:00",
+                        "registratiedatumTot": "2024-09-26T00:00:00-00:00",
                     },
                     headers=AUDIT_HEADERS,
                 )
@@ -482,8 +482,8 @@ class PublicationApiTests(TokenAuthMixin, APITestCase):
             data = response.json()
 
             self.assertEqual(data["count"], 2)
-            self.assertEqual(data["results"][0]["uuid"], str(publication.uuid))
-            self.assertEqual(data["results"][1]["uuid"], str(publication2.uuid))
+            self.assertEqual(data["results"][0]["uuid"], str(publication2.uuid))
+            self.assertEqual(data["results"][1]["uuid"], str(publication.uuid))
 
     def test_list_publications_filter_owner(self):
         ic, ic2 = InformationCategoryFactory.create_batch(2)


### PR DESCRIPTION
Fixes #68

**Changes**

Added 4 queryparams for publication endpoint:
- search (which is both title fields combined)
- registratie_datum (gte and lte)
- information_categories (comma seperated)

