### PR TITLE
Include the file download Content-Disposition header

### DIFF
--- a/src/woo_publications/api/openapi.yaml
+++ b/src/woo_publications/api/openapi.yaml
@@ -443,6 +443,10 @@ paths:
               schema:
                 type: string
               description: Total size in bytes of the download.
+            Content-Disposition:
+              schema:
+                type: string
+              description: Marks the file as attachment and includes the filename.
           content:
             application/octet-stream:
               schema:
@@ -455,6 +459,10 @@ paths:
               schema:
                 type: string
               description: Total size in bytes of the download.
+            Content-Disposition:
+              schema:
+                type: string
+              description: Marks the file as attachment and includes the filename.
           description: Bad gateway - failure to stream content.
   /api/v1/informatiecategorieen:
     get:

--- a/src/woo_publications/publications/api/viewsets.py
+++ b/src/woo_publications/publications/api/viewsets.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from django.db import transaction
 from django.http import StreamingHttpResponse
+from django.utils.http import content_disposition_header
 from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.utils import (
@@ -186,7 +187,16 @@ class DocumentViewSet(
                 location=OpenApiParameter.HEADER,
                 description=_("Total size in bytes of the download."),
                 response=(200,),
-            )
+            ),
+            OpenApiParameter(
+                name="Content-Disposition",
+                type=str,
+                location=OpenApiParameter.HEADER,
+                description=_(
+                    "Marks the file as attachment and includes the filename."
+                ),
+                response=(200,),
+            ),
         ],
     )
     @action(detail=True, methods=["get"], url_name="download")
@@ -231,7 +241,11 @@ class DocumentViewSet(
                 headers={
                     "Content-Length": upstream_response.headers.get(
                         "Content-Length", str(document.bestandsomvang)
-                    )
+                    ),
+                    "Content-Disposition": content_disposition_header(
+                        as_attachment=True,
+                        filename=document.bestandsnaam,
+                    ),
                 },
             )
 

--- a/src/woo_publications/publications/tests/test_document_api_endpoints.py
+++ b/src/woo_publications/publications/tests/test_document_api_endpoints.py
@@ -1076,6 +1076,7 @@ class DocumentDownloadTests(VCRMixin, TokenAuthMixin, APITestCase):
         assert isinstance(response, StreamingHttpResponse)
         self.assertTrue(response.streaming)
         self.assertEqual(response["Content-Length"], "5")
+        self.assertIn("Content-Disposition", response)
 
         assert isinstance(response.streaming_content, Iterator)
         content = b"".join(response.streaming_content)


### PR DESCRIPTION
Fixes #146

**Changes**

Added `Content-Disposition` response header for file download endpoint

