### PR TITLE
Feature/73 diwoo informatie categorieen improved query

### DIFF
--- a/src/woo_publications/metadata/service.py
+++ b/src/woo_publications/metadata/service.py
@@ -4,9 +4,9 @@ from django.core.cache import cache
 from .models import InformationCategory
 
 
-def get_inspannings_verplicting():
+def get_inspannings_verplichting():
     inspannings_verplicht = cache.get_or_set(
-        "inspannings_verplicting",
+        "inspannings_verplichting",
         lambda: InformationCategory.objects.get(
             identifier=settings.INSPANNINGSVERPLICHTING_IDENTIFIER
         ),

--- a/src/woo_publications/publications/models.py
+++ b/src/woo_publications/publications/models.py
@@ -26,7 +26,7 @@ from woo_publications.logging.service import (
 from woo_publications.logging.typing import ActingUser
 from woo_publications.metadata.constants import InformationCategoryOrigins
 from woo_publications.metadata.models import InformationCategory
-from woo_publications.metadata.service import get_inspannings_verplicting
+from woo_publications.metadata.service import get_inspannings_verplichting
 
 from .constants import DocumentActionTypeOptions, PublicationStatusOptions
 from .typing import DocumentActions
@@ -178,7 +178,7 @@ class Publication(ModelOwnerMixin, models.Model):
                 sitemap_uuid=models.Case(
                     models.When(
                         oorsprong=InformationCategoryOrigins.custom_entry,
-                        then=models.Value(get_inspannings_verplicting().uuid),
+                        then=models.Value(get_inspannings_verplichting().uuid),
                     ),
                     default=models.F("uuid"),
                 )

--- a/src/woo_publications/publications/tests/test_publications_api.py
+++ b/src/woo_publications/publications/tests/test_publications_api.py
@@ -100,12 +100,9 @@ class PublicationApiTestsCase(TokenAuthMixin, APITestCaseMixin, APITestCase):
             identifier=settings.INSPANNINGSVERPLICHTING_IDENTIFIER,
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        # the get_inspannings_verplicting func which is called while fetching the diWooInformatieCategorieen data is cached.
+        # the get_inspannings_verplichting func which is called while fetching the diWooInformatieCategorieen data is cached.
         # so we clear the cache after each test to maintain test isolation.
-        cache.clear()
+        cls.addClassCleanup(cache.clear)
 
     def test_list_publications(self):
         ic, ic2 = InformationCategoryFactory.create_batch(
@@ -964,7 +961,7 @@ class PublicationApiTestsCase(TokenAuthMixin, APITestCaseMixin, APITestCase):
             }
 
             # diWooInformatieCategorieen ordering is done on the UUID field to make sure there are no duplicated data.
-            # Which results in unpredictable ordering for testing, so I rest these individually
+            # Which results in unpredictable ordering for testing, so I test these individually
             self.assertIn(str(ic.uuid), response_data["diWooInformatieCategorieen"])
             self.assertIn(str(ic2.uuid), response_data["diWooInformatieCategorieen"])
             del response_data["diWooInformatieCategorieen"]


### PR DESCRIPTION
Improves #174 

**Changes**

- Reduced the queries made to retrieve the `di_woo_informatie_categorieen`.
- Cache the inspannings_verplicting information category record to improve performance.

