### PR TITLE
Deprecate document identifier

### DIFF
--- a/src/woo_publications/api/openapi.yaml
+++ b/src/woo_publications/api/openapi.yaml
@@ -1876,6 +1876,7 @@ components:
           title: Identificatie
           description: De (primaire) unieke identificatie.
           maxLength: 255
+          deprecated: true
         publicatie:
           type: string
           format: uuid
@@ -2019,6 +2020,7 @@ components:
           title: Identificatie
           description: De (primaire) unieke identificatie.
           maxLength: 255
+          deprecated: true
         publicatie:
           type: string
           format: uuid
@@ -2197,6 +2199,7 @@ components:
           readOnly: true
           title: Identificatie
           description: De (primaire) unieke identificatie.
+          deprecated: true
         publicatie:
           type: string
           format: uuid
@@ -2624,6 +2627,7 @@ components:
           readOnly: true
           title: Identificatie
           description: De (primaire) unieke identificatie.
+          deprecated: true
         publicatie:
           type: string
           format: uuid

--- a/src/woo_publications/publications/admin.py
+++ b/src/woo_publications/publications/admin.py
@@ -565,7 +565,6 @@ class DocumentAdmin(AdminAuditLogMixin, admin.ModelAdmin):
             {
                 "fields": (
                     "publicatie",
-                    "identifier",
                     "officiele_titel",
                     "verkorte_titel",
                     "omschrijving",
@@ -595,6 +594,13 @@ class DocumentAdmin(AdminAuditLogMixin, admin.ModelAdmin):
                     "lock",
                     "upload_complete",
                 )
+            },
+        ),
+        (
+            _("Deprecated fields"),
+            {
+                "classes": ["collapse"],
+                "fields": ("identifier",),
             },
         ),
     ]

--- a/src/woo_publications/publications/api/serializers.py
+++ b/src/woo_publications/publications/api/serializers.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from django_fsm import FSMField
 from drf_polymorphic.serializers import PolymorphicSerializer
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
 from rest_framework import serializers
 from rest_framework.request import Request
 
@@ -157,6 +157,7 @@ class DocumentIdentifierSerializer(serializers.ModelSerializer[DocumentIdentifie
         )
 
 
+@extend_schema_serializer(deprecate_fields=("identifier",))
 class DocumentSerializer(serializers.ModelSerializer[Document]):
     publicatie = serializers.SlugRelatedField(
         queryset=Publication.objects.all(),

--- a/src/woo_publications/publications/models.py
+++ b/src/woo_publications/publications/models.py
@@ -613,6 +613,7 @@ class Document(ConcurrentTransitionMixin, models.Model):
         help_text=_("The owner of this document from gpp-app or gpp-publicatiebank."),
         on_delete=models.PROTECT,
     )
+    # TODO: remove this field in future release because it is deprecated
     identifier = models.CharField(
         _("identifier"),
         help_text=_("The (primary) unique identifier."),


### PR DESCRIPTION
Fixes #340

**Changes**

Mark the document field `identifier` as deprecated:
- in the admin moved it to a collapsed fieldset named deprecated fields
- in the api used the deprecate_fields from spectacular 
