### PR TITLE
:arrow_up: Upgrade open-api-framework

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -206,7 +206,9 @@ django-treebeard==4.7.1
 django-two-factor-auth==1.17.0
     # via maykin-2fa
 django-upgrade-check==1.1.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   open-api-framework
 djangorestframework==3.15.2
     # via
     #   commonground-api-common
@@ -294,7 +296,7 @@ mozilla-django-oidc-db==0.19.0
     # via open-api-framework
 notifications-api-common==0.7.2
     # via commonground-api-common
-open-api-framework==0.9.6
+open-api-framework==0.11.0
     # via -r requirements/base.in
 orderedmultidict==1.0.1
     # via furl
@@ -310,8 +312,10 @@ prometheus-client==0.20.0
     # via flower
 prompt-toolkit==3.0.47
     # via click-repl
-psycopg2==2.9.9
+psycopg==3.2.9
     # via open-api-framework
+psycopg-binary==3.2.9
+    # via psycopg
 pycparser==2.22
     # via cffi
 pygments==2.18.0
@@ -398,6 +402,7 @@ typing-extensions==4.12.2
     # via
     #   django-stubs-ext
     #   mozilla-django-oidc-db
+    #   psycopg
     #   pyopenssl
     #   qrcode
     #   zgw-consumers

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -353,6 +353,7 @@ django-upgrade-check==1.1.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+    #   open-api-framework
 django-webtest==1.9.13
     # via -r requirements/test-tools.in
 djangorestframework==3.15.2
@@ -554,7 +555,7 @@ notifications-api-common==0.7.2
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   commonground-api-common
-open-api-framework==0.9.6
+open-api-framework==0.11.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -594,11 +595,16 @@ prompt-toolkit==3.0.47
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   click-repl
-psycopg2==2.9.9
+psycopg==3.2.9
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   open-api-framework
+psycopg-binary==3.2.9
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   psycopg
 pycparser==2.22
     # via
     #   -c requirements/base.txt
@@ -801,6 +807,7 @@ typing-extensions==4.12.2
     #   django-stubs-ext
     #   django-test-migrations
     #   mozilla-django-oidc-db
+    #   psycopg
     #   pyopenssl
     #   qrcode
     #   zgw-consumers

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -382,6 +382,7 @@ django-upgrade-check==1.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   open-api-framework
 django-webtest==1.9.13
     # via
     #   -c requirements/ci.txt
@@ -605,7 +606,7 @@ notifications-api-common==0.7.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   commonground-api-common
-open-api-framework==0.9.6
+open-api-framework==0.11.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -649,11 +650,16 @@ prompt-toolkit==3.0.47
     #   -r requirements/ci.txt
     #   click-repl
     #   questionary
-psycopg2==2.9.9
+psycopg==3.2.9
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   open-api-framework
+psycopg-binary==3.2.9
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   psycopg
 pycparser==2.22
     # via
     #   -c requirements/ci.txt
@@ -917,6 +923,7 @@ typing-extensions==4.12.2
     #   django-stubs-ext
     #   django-test-migrations
     #   mozilla-django-oidc-db
+    #   psycopg
     #   pydantic
     #   pydantic-core
     #   pyopenssl

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -381,6 +381,7 @@ django-upgrade-check==1.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+    #   open-api-framework
 django-webtest==1.9.13
     # via
     #   -c requirements/ci.txt
@@ -600,7 +601,7 @@ notifications-api-common==0.7.2
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   commonground-api-common
-open-api-framework==0.9.6
+open-api-framework==0.11.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -643,11 +644,16 @@ prompt-toolkit==3.0.47
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   click-repl
-psycopg2==2.9.9
+psycopg==3.2.9
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   open-api-framework
+psycopg-binary==3.2.9
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   psycopg
 pycparser==2.22
     # via
     #   -c requirements/ci.txt
@@ -900,6 +906,7 @@ typing-extensions==4.12.2
     #   django-test-migrations
     #   djangorestframework-stubs
     #   mozilla-django-oidc-db
+    #   psycopg
     #   pyopenssl
     #   qrcode
     #   zgw-consumers

--- a/src/woo_publications/conf/base.py
+++ b/src/woo_publications/conf/base.py
@@ -27,7 +27,6 @@ INSTALLED_APPS = INSTALLED_APPS + [
     "maykin_common",
     "timeline_logger",
     "treebeard",
-    "upgrade_check",
     "drf_polymorphic",
     # Project applications.
     "woo_publications.accounts",


### PR DESCRIPTION
This now uses psycopg 3 instead of psycopg2, noice.
