### PR TITLE
Use plain charfield for phone number

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,6 @@ celery
 flower
 furl
 Pillow
-phonenumberslite
 pypdf
 python-magic
 structlog

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -237,8 +237,6 @@ orderedmultidict==1.0.2
     # via furl
 packaging==26.0
     # via kombu
-phonenumberslite==9.0.22
-    # via -r requirements/base.in
 pillow==12.1.0
     # via -r requirements/base.in
 polib==1.2.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -456,10 +456,6 @@ packaging==26.0
     #   -r requirements/base.txt
     #   kombu
     #   sphinx
-phonenumberslite==9.0.22
-    # via
-    #   -c requirements/base.txt
-    #   -r requirements/base.txt
 pillow==12.1.0
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -520,10 +520,6 @@ packaging==26.0
     #   -r requirements/ci.txt
     #   kombu
     #   sphinx
-phonenumberslite==9.0.22
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
 pillow==12.1.0
     # via
     #   -c requirements/ci.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -507,10 +507,6 @@ packaging==26.0
     #   -r requirements/ci.txt
     #   kombu
     #   sphinx
-phonenumberslite==9.0.22
-    # via
-    #   -c requirements/ci.txt
-    #   -r requirements/ci.txt
 pillow==12.1.0
     # via
     #   -c requirements/ci.txt

--- a/src/woo_publications/api/migrations/0001_initial.py
+++ b/src/woo_publications/api/migrations/0001_initial.py
@@ -3,7 +3,6 @@
 from django.db import migrations, models
 
 import django_jsonform.models.fields
-import phonenumber_field.modelfields
 
 
 class Migration(migrations.Migration):
@@ -59,11 +58,10 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "phone_number",
-                    phonenumber_field.modelfields.PhoneNumberField(
+                    models.CharField(
                         blank=True,
                         help_text="Phonenumber of the person contact about this application and the associated credentials.",
                         max_length=128,
-                        region=None,
                         verbose_name="phone number",
                     ),
                 ),

--- a/src/woo_publications/api/models.py
+++ b/src/woo_publications/api/models.py
@@ -5,7 +5,6 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from django_jsonform.models.fields import ArrayField
-from phonenumber_field.modelfields import PhoneNumberField
 
 from .constants import PermissionOptions
 
@@ -48,8 +47,9 @@ class Application(models.Model):  # noqa: DJ008
         ),
         blank=True,
     )
-    phone_number = PhoneNumberField(
+    phone_number = models.CharField(
         _("phone number"),
+        max_length=128,
         help_text=_(
             "Phonenumber of the person contact about this application and the "
             "associated credentials."


### PR DESCRIPTION
Fixes #384

We don't need to process the phone number values in automated ways, this field is only meant for a human to be able to contact a person that uses the API key.

Instead of fiddling with the phone number validation, use a plain charfield instead and trust the admin users to enter useful info.
