### PR TITLE
strip and index retrieve url documents

### DIFF
--- a/src/woo_publications/publications/tasks.py
+++ b/src/woo_publications/publications/tasks.py
@@ -66,6 +66,9 @@ def strip_metadata(*, document_id: int, base_url: str) -> None:
         "The document must have a Documents API object attached"
     )
 
+    if not document.has_to_strip_metadata:
+        return  # bail out, task completes successfully
+
     # - get client instance for the documents api
     # - create temporary named file to create a pdf which we can strip
     with (

--- a/src/woo_publications/publications/tests/test_strip_meta_data_task.py
+++ b/src/woo_publications/publications/tests/test_strip_meta_data_task.py
@@ -126,6 +126,17 @@ class StripMetaDataTaskTestCase(VCRMixin, TestCase):
 
         self.assertEqual(doc.metadata_gestript_op, None)
 
+    def test_skip_file_which_should_not_be_stripped(self):
+        doc = DocumentFactory.create(
+            publicatiestatus=PublicationStatusOptions.published,
+            document_service=self.service,
+            document_uuid=uuid4(),
+        )
+
+        strip_metadata(document_id=doc.pk, base_url="http://testserver/")
+
+        self.assertEqual(doc.metadata_gestript_op, None)
+
     def test_strip_pdf_of_metadata(self):
         with METADATA_PDF.open("rb") as pdf_file:
             reader = PdfReader(pdf_file)


### PR DESCRIPTION
Fixes #413

**Changes**

Ensured that the document gets indexed (and stripped if needed)

