### PR TITLE
Fixes #449 -- make hardcoded uwsgi flags overridable via environment variables

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -12,6 +12,10 @@ fixtures_dir=${FIXTURES_DIR:-/app/fixtures}
 uwsgi_port=${UWSGI_PORT:-8000}
 uwsgi_processes=${UWSGI_PROCESSES:-4}
 uwsgi_threads=${UWSGI_THREADS:-1}
+uwsgi_http_timeout=${UWSGI_HTTP_TIMEOUT:-1800}
+uwsgi_harakiri=${UWSGI_HARAKIRI:-1800}
+uwsgi_post_buffering=${UWSGI_POST_BUFFERING:-8192}
+uwsgi_buffer_size=${UWSGI_BUFFER_SIZE:-65535}
 
 mountpoint=${SUBPATH:-/}
 
@@ -68,7 +72,7 @@ exec uwsgi \
     --master \
     --http :$uwsgi_port \
     --http-keepalive \
-    --http-timeout=1800 \
+    --http-timeout=$uwsgi_http_timeout \
     --manage-script-name \
     --mount $mountpoint=woo_publications.wsgi:application \
     --static-map /static=/app/static \
@@ -77,7 +81,7 @@ exec uwsgi \
     --enable-threads \
     --processes $uwsgi_processes \
     --threads $uwsgi_threads \
-    --post-buffering=8192 \
-    --buffer-size=65535 \
-    --harakiri=1800
+    --post-buffering=$uwsgi_post_buffering \
+    --buffer-size=$uwsgi_buffer_size \
+    --harakiri=$uwsgi_harakiri
     # processes & threads are needed for concurrency without nginx sitting inbetween

--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -10,12 +10,17 @@ export PGPORT=${DB_PORT:-5432}
 fixtures_dir=${FIXTURES_DIR:-/app/fixtures}
 
 uwsgi_port=${UWSGI_PORT:-8000}
-uwsgi_processes=${UWSGI_PROCESSES:-4}
-uwsgi_threads=${UWSGI_THREADS:-1}
-uwsgi_http_timeout=${UWSGI_HTTP_TIMEOUT:-1800}
-uwsgi_harakiri=${UWSGI_HARAKIRI:-1800}
-uwsgi_post_buffering=${UWSGI_POST_BUFFERING:-8192}
-uwsgi_buffer_size=${UWSGI_BUFFER_SIZE:-65535}
+
+# uwsgi reads UWSGI_* environment variables natively, but explicit CLI flags take
+# precedence over them - so export defaults instead of passing flags, allowing the
+# infra-layer to override any of these without code changes.
+# processes & threads are needed for concurrency without nginx sitting inbetween.
+export UWSGI_PROCESSES=${UWSGI_PROCESSES:-4}
+export UWSGI_THREADS=${UWSGI_THREADS:-1}
+export UWSGI_HTTP_TIMEOUT=${UWSGI_HTTP_TIMEOUT:-1800}
+export UWSGI_HARAKIRI=${UWSGI_HARAKIRI:-1800}
+export UWSGI_POST_BUFFERING=${UWSGI_POST_BUFFERING:-8192}
+export UWSGI_BUFFER_SIZE=${UWSGI_BUFFER_SIZE:-65535}
 
 mountpoint=${SUBPATH:-/}
 
@@ -72,16 +77,9 @@ exec uwsgi \
     --master \
     --http :$uwsgi_port \
     --http-keepalive \
-    --http-timeout=$uwsgi_http_timeout \
     --manage-script-name \
     --mount $mountpoint=woo_publications.wsgi:application \
     --static-map /static=/app/static \
     --static-map /media=/app/media  \
     --chdir src \
-    --enable-threads \
-    --processes $uwsgi_processes \
-    --threads $uwsgi_threads \
-    --post-buffering=$uwsgi_post_buffering \
-    --buffer-size=$uwsgi_buffer_size \
-    --harakiri=$uwsgi_harakiri
-    # processes & threads are needed for concurrency without nginx sitting inbetween
+    --enable-threads


### PR DESCRIPTION
Fixes #449

**Changes**

`bin/docker_start.sh`: export `UWSGI_PROCESSES`, `UWSGI_THREADS`, `UWSGI_HTTP_TIMEOUT`, `UWSGI_HARAKIRI`, `UWSGI_POST_BUFFERING` and `UWSGI_BUFFER_SIZE` with the previous values as defaults, and drop the matching explicit CLI flags — uwsgi picks the env vars up natively, so the infra-layer can override any of them without code changes. Effective defaults are unchanged.
