### PR TITLE
Fixes #451 -- use a dedicated read timeout for file part uploads and document unlock

### DIFF
--- a/src/woo_publications/conf/base.py
+++ b/src/woo_publications/conf/base.py
@@ -227,6 +227,17 @@ LOGIN_URLS = [reverse_lazy("admin:login")]
 # Default (connection timeout, read timeout) for the requests library (in seconds)
 REQUESTS_DEFAULT_TIMEOUT = (10, 30)
 
+DOCUMENTS_API_SLOW_OPERATIONS_TIMEOUT = config(  # pyright: ignore[reportCallIssue]
+    "DOCUMENTS_API_SLOW_OPERATIONS_TIMEOUT",
+    default=5 * 60,
+    help_text=(
+        "Read timeout (in seconds) for Documents API calls whose duration scales "
+        "with document size and storage speed: uploading a file part, and unlocking "
+        "a document (which merges the uploaded parts server-side). A higher timeout "
+        "configured on the Documents API service itself takes precedence."
+    ),
+)
+
 # The Identifier of `inspanningsverplichting` from the gov origins list for the
 # Information Categories.
 INSPANNINGSVERPLICHTING_IDENTIFIER = (

--- a/src/woo_publications/contrib/documents_api/client.py
+++ b/src/woo_publications/contrib/documents_api/client.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from typing import Protocol
 from uuid import UUID
 
+from django.conf import settings
 from django.core.files import File
 from django.core.files.uploadedfile import (
     InMemoryUploadedFile,
@@ -94,6 +95,22 @@ class DocumentenClient(NLXClient):
 
     Requires Documenten API 1.1+ since we use the large file uploads mechanism.
     """
+
+    def _slow_operations_timeout(self) -> float | int:
+        """
+        Return the read timeout for calls whose duration scales with document size.
+
+        Uploading a file part and unlocking a document (which makes the Documents
+        API merge all uploaded parts server-side) take longer the larger the
+        document and the slower its storage backend. The generic per-service
+        timeout (default: 10 seconds) aborts these calls for large documents, so
+        apply a dedicated floor while still respecting a higher timeout configured
+        on the service.
+        """
+        configured = self._request_kwargs.get("timeout")
+        if not isinstance(configured, (int, float)):
+            configured = 0
+        return max(configured, settings.DOCUMENTS_API_SLOW_OPERATIONS_TIMEOUT)
 
     def retrieve_document(self, *, url: str = "", uuid: UUID | None = None) -> Document:
         assert url or uuid
@@ -207,6 +224,7 @@ class DocumentenClient(NLXClient):
             f"bestandsdelen/{file_part_uuid}",
             data=encoder,
             headers={"Content-Type": encoder.content_type},
+            timeout=self._slow_operations_timeout(),
         )
         response.raise_for_status()
 
@@ -233,6 +251,7 @@ class DocumentenClient(NLXClient):
         response = self.post(
             f"enkelvoudiginformatieobjecten/{uuid}/unlock",
             json={"lock": lock},
+            timeout=self._slow_operations_timeout(),
         )
         response.raise_for_status()
 

--- a/src/woo_publications/contrib/documents_api/tests/test_client.py
+++ b/src/woo_publications/contrib/documents_api/tests/test_client.py
@@ -33,7 +33,7 @@ from requests import RequestException
 from woo_publications.contrib.tests.factories import ServiceFactory
 from woo_publications.utils.tests.vcr import VCRMixin
 
-from ..client import DocumentsAPIError, get_client
+from ..client import DocumentenClient, DocumentsAPIError, get_client
 
 DOCUMENT_TYPE_URL = (
     "http://host.docker.internal:8000/catalogi/api/v1/informatieobjecttypen/"
@@ -360,3 +360,18 @@ class SlowOperationsTimeoutTests(TestCase):
             client.lock_document(uuid4())
 
         self.assertEqual(m.last_request.timeout, 10)
+
+    def test_tuple_configured_timeout_falls_back_to_floor(self):
+        # request_kwargs may carry a (connect, read) timeout tuple instead of a
+        # number — there is no meaningful comparison then, so the floor applies.
+        client = DocumentenClient(
+            "https://documents.example.com/api/v1/",
+            request_kwargs={"timeout": (10, 30)},
+        )
+
+        with client, requests_mock.Mocker() as m:
+            m.post(requests_mock.ANY, status_code=204)
+
+            client.unlock_document(uuid=uuid4(), lock="a-lock-value")
+
+        self.assertEqual(m.last_request.timeout, 300)

--- a/src/woo_publications/contrib/documents_api/tests/test_client.py
+++ b/src/woo_publications/contrib/documents_api/tests/test_client.py
@@ -27,6 +27,7 @@ from uuid import UUID, uuid4
 from django.core.files import File
 from django.test import TestCase, override_settings
 
+import requests_mock
 from requests import RequestException
 
 from woo_publications.contrib.tests.factories import ServiceFactory
@@ -277,3 +278,85 @@ class DocumentsAPIClientTests(VCRMixin, TestCase):
             )
             self.assertEqual(upstream_response.status_code, 500)
             self.assertEqual(streaming_content, (b"",))
+
+
+class SlowOperationsTimeoutTests(TestCase):
+    """
+    Uploading file parts and unlocking documents must not use the generic
+    (short) service timeout — their duration scales with document size and
+    storage speed on the Documents API side.
+
+    These tests assert on the ``timeout`` passed to the transport, so no VCR
+    cassettes are involved.
+    """
+
+    def _do_upload_and_unlock(self, client) -> None:
+        client.proxy_file_part_upload(
+            File(BytesIO(b"content")),
+            file_part_uuid=uuid4(),
+            lock="a-lock-value",
+        )
+        client.unlock_document(uuid=uuid4(), lock="a-lock-value")
+
+    def test_slow_operations_get_dedicated_read_timeout(self):
+        service = ServiceFactory.build(
+            api_root="https://documents.example.com/api/v1/",
+            timeout=10,
+        )
+
+        with get_client(service) as client, requests_mock.Mocker() as m:
+            m.put(requests_mock.ANY, status_code=200)
+            m.post(requests_mock.ANY, status_code=204)
+
+            self._do_upload_and_unlock(client)
+
+        self.assertEqual(len(m.request_history), 2)
+        for request in m.request_history:
+            with self.subTest(method=request.method, url=request.url):
+                self.assertEqual(request.timeout, 300)
+
+    def test_higher_configured_service_timeout_takes_precedence(self):
+        service = ServiceFactory.build(
+            api_root="https://documents.example.com/api/v1/",
+            timeout=900,
+        )
+
+        with get_client(service) as client, requests_mock.Mocker() as m:
+            m.put(requests_mock.ANY, status_code=200)
+            m.post(requests_mock.ANY, status_code=204)
+
+            self._do_upload_and_unlock(client)
+
+        for request in m.request_history:
+            with self.subTest(method=request.method, url=request.url):
+                self.assertEqual(request.timeout, 900)
+
+    @override_settings(DOCUMENTS_API_SLOW_OPERATIONS_TIMEOUT=42)
+    def test_timeout_is_configurable(self):
+        service = ServiceFactory.build(
+            api_root="https://documents.example.com/api/v1/",
+            timeout=10,
+        )
+
+        with get_client(service) as client, requests_mock.Mocker() as m:
+            m.put(requests_mock.ANY, status_code=200)
+            m.post(requests_mock.ANY, status_code=204)
+
+            self._do_upload_and_unlock(client)
+
+        for request in m.request_history:
+            with self.subTest(method=request.method, url=request.url):
+                self.assertEqual(request.timeout, 42)
+
+    def test_other_calls_keep_the_service_timeout(self):
+        service = ServiceFactory.build(
+            api_root="https://documents.example.com/api/v1/",
+            timeout=10,
+        )
+
+        with get_client(service) as client, requests_mock.Mocker() as m:
+            m.post(requests_mock.ANY, status_code=200, json={"lock": "a-lock-value"})
+
+            client.lock_document(uuid4())
+
+        self.assertEqual(m.last_request.timeout, 10)


### PR DESCRIPTION
Fixes #451

**Changes**

`proxy_file_part_upload()` and `unlock_document()` now pass an explicit per-call read timeout: `max(service timeout, DOCUMENTS_API_SLOW_OPERATIONS_TIMEOUT)`. The new setting is env-configurable and defaults to 300 seconds; all other calls keep using the timeout configured on the service. Includes transport-level tests (requests-mock, no cassettes).
