### PR TITLE
Fixes #453 -- recycle celery pool children by default to bound worker memory

### DIFF
--- a/bin/celery_worker.sh
+++ b/bin/celery_worker.sh
@@ -5,6 +5,14 @@ set -e
 LOGLEVEL=${CELERY_LOGLEVEL:-INFO}
 CONCURRENCY=${CELERY_WORKER_CONCURRENCY:-1}
 
+# Celery reads CELERY_WORKER_* environment variables natively (Click
+# auto_envvar_prefix="CELERY"), so any worker option can be overridden from the
+# environment. Default to recycling pool children periodically so memory
+# released by completed tasks is returned to the OS instead of accumulating in
+# a long-lived child process. Recycling happens between tasks; no work is lost.
+# CELERY_WORKER_MAX_MEMORY_PER_CHILD (in KiB) can be set as a companion limit.
+export CELERY_WORKER_MAX_TASKS_PER_CHILD=${CELERY_WORKER_MAX_TASKS_PER_CHILD:-50}
+
 QUEUE=${CELERY_WORKER_QUEUE:=celery}
 WORKER_NAME=${CELERY_WORKER_NAME:="${QUEUE}"@%n}
 


### PR DESCRIPTION
Closes #453

Exports an overridable `CELERY_WORKER_MAX_TASKS_PER_CHILD=50` default in `bin/celery_worker.sh`, bounding the RSS growth of the long-lived pool child described in #453. Celery binds `CELERY_WORKER_*` environment variables to worker CLI options natively (`auto_envvar_prefix="CELERY"`), so no explicit flag is needed and deployments can override or disable (`0`) it — same pattern as #450.
Imposing a default, non-zero maxRequests for the Celery worker prevents workers from eventually exceeding their memory limit - getting the in-flight request OOMKilled and the upload failed. Or end up consuming all memory. ;)